### PR TITLE
multivariate input values for probabilistic networks

### DIFF
--- a/pyhgf/plots.py
+++ b/pyhgf/plots.py
@@ -311,12 +311,10 @@ def plot_network(hgf: "HGF") -> "Source":
     graphviz_structure.attr("node", shape="circle")
 
     # set input nodes
-    list_of_input_idx = []
-    for input_node in hgf.input_nodes_idx:
-        list_of_input_idx.append(input_node.idx)
+    for idx, kind in zip(hgf.input_nodes_idx.idx, hgf.input_nodes_idx.kind):
         graphviz_structure.node(
-            f"x_{input_node.idx}",
-            label=f"{input_node.kind.capitalize()[0]}I - {input_node.idx}",
+            f"x_{idx}",
+            label=f"{kind.capitalize()[0]}I - {idx}",
             style="filled",
             shape="octagon",
         )
@@ -324,12 +322,12 @@ def plot_network(hgf: "HGF") -> "Source":
     # create the rest of nodes
     for i in range(len(hgf.node_structure)):
         # only if node is not an input node
-        if i not in list_of_input_idx:
+        if i not in hgf.input_nodes_idx.idx:
             graphviz_structure.node(f"x_{i}", label=str(i), shape="circle")
 
     # connect value parents
-    for i, idx in enumerate(hgf.node_structure):
-        value_parents = idx.value_parents
+    for i, index in enumerate(hgf.node_structure):
+        value_parents = index.value_parents
 
         if value_parents is not None:
             for value_parents_idx in value_parents:
@@ -339,8 +337,8 @@ def plot_network(hgf: "HGF") -> "Source":
                 )
 
     # connect volatility parents
-    for i, idx in enumerate(hgf.node_structure):
-        volatility_parents = idx.volatility_parents
+    for i, index in enumerate(hgf.node_structure):
+        volatility_parents = index.volatility_parents
 
         if volatility_parents is not None:
             for volatility_parents_idx in volatility_parents:

--- a/pyhgf/response.py
+++ b/pyhgf/response.py
@@ -70,15 +70,13 @@ def total_gaussian_surprise(hgf: "HGF", response_function_parameters=None):
     surprise = 0.0
 
     # first we start with nodes that are value parents to input nodes
-    input_idx_list = []
     input_parents_list = []
-    for inp in hgf.input_nodes_idx:
-        input_idx_list.append(inp.idx)
-        va_pa = hgf.node_structure[inp.idx].value_parents[0]  # type: ignore
+    for idx in hgf.input_nodes_idx.idx:
+        va_pa = hgf.node_structure[idx].value_parents[0]  # type: ignore
         input_parents_list.append(va_pa)
         surprise += jnp.sum(
             gaussian_surprise(
-                x=hgf.node_trajectories[inp.idx]["value"][1:],
+                x=hgf.node_trajectories[idx]["value"][1:],
                 muhat=hgf.node_trajectories[va_pa]["muhat"][:-1],
                 pihat=hgf.node_trajectories[va_pa]["pihat"][:-1],
             )
@@ -87,7 +85,7 @@ def total_gaussian_surprise(hgf: "HGF", response_function_parameters=None):
     # then we do the same for every node that is not an input node
     # and not the parent of an input node
     for i in range(len(hgf.node_structure)):
-        if (i not in input_idx_list) and (i not in input_parents_list):
+        if (i not in hgf.input_nodes_idx.idx) and (i not in input_parents_list):
             surprise += jnp.sum(
                 gaussian_surprise(
                     x=hgf.node_trajectories[i]["mu"][1:],

--- a/pyhgf/typing.py
+++ b/pyhgf/typing.py
@@ -1,6 +1,6 @@
 # Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
 
-from typing import Callable, NamedTuple, Optional, Tuple
+from typing import Callable, List, NamedTuple, Optional, Tuple
 
 
 class Indexes(NamedTuple):
@@ -11,10 +11,10 @@ class Indexes(NamedTuple):
 
 
 class InputIndexes(NamedTuple):
-    """Input node type and index."""
+    """Input nodes type and index."""
 
-    idx: int
-    kind: str
+    idx: List[int]
+    kind: List[str]
 
 
 NodeStructure = Tuple[Indexes, ...]

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -91,7 +91,8 @@ class Testbinary(TestCase):
             parameters_structure=parameters_structure,
             update_sequence=update_sequence, 
             time_step=1.0,
-            value=1.0
+            values=jnp.array([1.0]),
+            input_nodes_idx=jnp.array([0])
             )
         assert new_parameters_structure[0]["surprise"] == 0.31326166
 
@@ -101,12 +102,12 @@ class Testbinary(TestCase):
         # Create the data (value and time steps vectors)
         data = jnp.array([timeserie, jnp.ones(len(timeserie), dtype=int)]).T
 
-
         # create the function that will be scaned
         scan_fn = Partial(
             loop_inputs, 
             update_sequence=update_sequence, 
-            node_structure=node_structure
+            node_structure=node_structure,
+            input_nodes_idx=jnp.array([0])
             )
 
         # Run the entire for loop

--- a/tests/test_continuous.py
+++ b/tests/test_continuous.py
@@ -64,7 +64,8 @@ class Testcontinuous(TestCase):
             time_step=1.0,
             node_structure=node_structure,
             update_sequence=update_sequence, 
-            value=None
+            values=jnp.nan,
+            input_nodes_idx=jnp.array([0])
             )
 
         assert parameters_structure == new_parameters_structure
@@ -85,7 +86,8 @@ class Testcontinuous(TestCase):
             time_step=1.0,
             node_structure=node_structure,
             update_sequence=update_sequence, 
-            value=None
+            values=jnp.nan,
+            input_nodes_idx=jnp.array([0])
             )
 
         assert jnp.isclose(
@@ -109,7 +111,8 @@ class Testcontinuous(TestCase):
             time_step=1.0,
             node_structure=node_structure,
             update_sequence=update_sequence, 
-            value=None
+            values=jnp.nan,
+            input_nodes_idx=jnp.array([0])
             )
         assert jnp.isclose(
             new_node_structure[1]["pi"],
@@ -132,7 +135,8 @@ class Testcontinuous(TestCase):
             time_step=1.0,
             node_structure=node_structure,
             update_sequence=update_sequence, 
-            value=None
+            values=jnp.nan,
+            input_nodes_idx=jnp.array([0])
             )
         assert jnp.isclose(
             new_node_structure[1]["pi"],
@@ -185,7 +189,7 @@ class Testcontinuous(TestCase):
             node_parameters,
             node_parameters,
         )
-        
+
         # create update sequence
         sequence1 = 0, continuous_input_update
         sequence2 = 1, continuous_node_update
@@ -197,7 +201,8 @@ class Testcontinuous(TestCase):
             parameters_structure=parameters_structure,
             update_sequence=update_sequence, 
             time_step=1.0,
-            value=.2
+            values=.2,
+            input_nodes_idx=jnp.array([0])
             )
 
         assert new_parameters_structure[1]["pi"] == 0.48708236
@@ -251,7 +256,8 @@ class Testcontinuous(TestCase):
         scan_fn = Partial(
             loop_inputs, 
             update_sequence=update_sequence, 
-            node_structure=node_structure
+            node_structure=node_structure,
+            input_nodes_idx=jnp.array([0])
             )
 
         # Run the entire for loop

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -2,14 +2,14 @@
 
 import unittest
 from unittest import TestCase
-import jax.numpy as jnp
 from pyhgf.continuous import continuous_input_update, continuous_node_update
-from pyhgf.structure import loop_inputs, apply_sequence
+from pyhgf.structure import apply_sequence
 from pyhgf.typing import Indexes
+import jax.numpy as jnp
 
 class TestStructure(TestCase):
 
-    def test_loop_inputs(self):
+    def test_apply_sequence(self):
         """Test the loop_inputs function"""
 
         ###############################################
@@ -57,7 +57,8 @@ class TestStructure(TestCase):
             parameters_structure=parameters_structure,
             update_sequence=update_sequence, 
             time_step=1.0,
-            value=.2
+            values=jnp.array([.2]),
+            input_nodes_idx=jnp.array([0])
             )
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR allows feeding probabilistic networks with more than one value at a time.

Inputs are now arrays, and the node index receiving the value is automatically sorted from the `InputIndexes` representation. Changes were required on the way we represent those variables, and they are now automatically passed to `loop_inputs` and `apply_sequence`.