### PR TITLE
add a second input_data method for models with time varying update sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # The multilevel, generalized and nodalized Hierarchical Gaussian Filter for predictive coding
 
-pyhgf is a Python library that implements the generalized, nodalized and multilevel Hierarchical Gaussian Filters for predictive coding written on top of [JAX](https://jax.readthedocs.io/en/latest/jax.html). The library can create and manipulate graph neural networks that perform beliefs update throught the diffusion of precision-weighted prediction errors under new observations. The core functions are derivable, JIT-able, and are designed to interface smoothly with other libraries in the JAX ecosystem for Bayesian inference.
+pyhgf is a Python library that implements the generalized, nodalized and multilevel Hierarchical Gaussian Filters for predictive coding written on top of [JAX](https://jax.readthedocs.io/en/latest/jax.html). The library can create and manipulate graph neural networks that perform belief update through the diffusion of precision-weighted prediction errors under new observations. The core functions are derivable, JIT-able, and are designed to interface smoothly with other libraries in the JAX ecosystem for Bayesian inference.
 
 * 🎓 [What is a Hierarchical Gaussian Filter?](https://ilabcode.github.io/pyhgf/theory.html)  
 * 📖 [API Documentation](https://ilabcode.github.io/pyhgf/)  
@@ -29,7 +29,7 @@ The nodalized Hierarchical Gaussian Filter consists of a network of probabilisti
 More generally, pyhgf operates on graph neural networks that can be defined and updated through the following variables:
 
 * The node parameters (dictionary) that store each node's parameters (value, precision, learning rates, volatility coupling, ...).
-* The node structure (tuple) that list, for each node, the indexes of the value and volatility parents.
+* The node structure (tuple) that lists, for each node, the indexes of the value and volatility parents.
 * A set of update functions that operate on any of the 3 other variables, starting from a target node.
 * An update sequence (tuple) that define the order in which the update functions are called, and the target node.
 
@@ -37,7 +37,7 @@ More generally, pyhgf operates on graph neural networks that can be defined and 
 
 Value parent and volatility parent are nodes themself. Any node can be a value and/or volatility parent for other nodes and have multiple value and/or volatility parents. A filtering structure consists of nodes embedding other nodes hierarchically. Nodes are parametrized by their sufficient statistic and parents. The transformations between nodes can be linear, non-linear, or any function (thus a *generalization* of the HGF).
 
-The resulting probabilistic network operates as a filter towards new observation. If a decision function (taking the whole model as a parameter) is also defined, behaviours can be triggered accordingly. By comparing those behaviours with actual outcomes, a surprise function can be optimized over the range of parameters of interest.
+The resulting probabilistic network operates as a filter toward new observation. If a decision function (taking the whole model as a parameter) is also defined, behaviors can be triggered accordingly. By comparing those behaviors with actual outcomes, a surprise function can be optimized over the range of parameters of interest.
 
 ### The Hierarchical Gaussian Filter
 
@@ -49,7 +49,7 @@ The pyhgf package includes pre-implemented standard HGF models that can be used 
 
 ### Model fitting
 
-Here we demonstrate how to fit a two-level binary Hierarchical Gaussian filter. The input time series are binary outcome from Iglesias et al. (2013).
+Here we demonstrate how to fit a two-level binary Hierarchical Gaussian filter. The input time series are the binary outcomes from Iglesias et al. (2013).
 
 ```python
 from pyhgf.model import HGF
@@ -87,7 +87,7 @@ hgf.plot_trajectories()
 
 # Acknoledgements
 
-This implementation of the Hierarchical Gaussian Filter was largely inspired by the original [Matlab version](https://translationalneuromodeling.github.io/tapas). A Julia implementation of the generalised, nodalised and multilevel HGF is also available [here](https://github.com/ilabcode/HGF.jl).
+This implementation of the Hierarchical Gaussian Filter was largely inspired by the original [Matlab version](https://translationalneuromodeling.github.io/tapas). A Julia implementation of the generalized, nodalised and multilevel HGF is also available [here](https://github.com/ilabcode/HGF.jl).
 
 ## References
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -110,3 +110,5 @@ Utilities for manipulating node structures and applying sequences.
    :toctree: generated/pyhgf.structure
 
    beliefs_propagation
+   trim_sequence
+   list_branches

--- a/pyhgf/binary.py
+++ b/pyhgf/binary.py
@@ -24,7 +24,7 @@ def binary_node_update(
     If the parents have value and/or volatility parents, they will be updated
     recursively.
 
-    Updating the node's parents is a two step process:
+    Updating the node's parents is a two-step process:
         1. Update value parent(s) and their parents (if provided).
         2. Update volatility parent(s) and their parents (if provided).
 
@@ -37,16 +37,16 @@ def binary_node_update(
         following parameters: `"pihat", "pi", "muhat", "mu", "nu", "psis", "omega"` for
         continuous nodes.
     .. note::
-        `"psis"` is the value coupling strength. It should have same length than the
+        `"psis"` is the value coupling strength. It should have the same length as the
         volatility parents' indexes. `"kappas"` is the volatility coupling strength.
-        It should have same length than the volatility parents' indexes.
+        It should have the same length as the volatility parents' indexes.
     time_step :
         Interval between the previous time point and the current time point.
     node_idx :
-        Pointer to the node that need to be updated. After continuous update, the
+        Pointer to the node that needs to be updated. After continuous updates, the
         parameters of value and volatility parents (if any) will be different.
     node_structure :
-        Tuple of :py:class:`pyhgf.typing.Indexes` with same length than number of node.
+        Tuple of :py:class:`pyhgf.typing.Indexes` with the same length as node number.
         For each node, the index list value and volatility parents.
 
     Returns
@@ -149,7 +149,7 @@ def binary_input_update(
 ) -> Dict:
     """Update the input node structure given one observation.
 
-    This function is the entry level of the model fitting. It update the partents of
+    This function is the entry-level of the model fitting. It updates the parents of
     the input node and then call :py:func:`pyhgf.binary.binary_node_update` to update
     the rest of the node structure.
 
@@ -158,20 +158,20 @@ def binary_input_update(
     value :
         The new observed value.
     time_step :
-        Interval between the previous time point and the current time point.
+        The interval between the previous time point and the current time point.
     parameters_structure :
         The structure of nodes' parameters. Each parameter is a dictionary with the
         following parameters: `"pihat", "pi", "muhat", "mu", "nu", "psis", "omega"` for
         continuous nodes.
     .. note::
-        `"psis"` is the value coupling strength. It should have same length than the
+        `"psis"` is the value coupling strength. It should have the same length as the
         volatility parents' indexes. `"kappas"` is the volatility coupling strength.
-        It should have same length than the volatility parents' indexes.
+        It should have the same length as the volatility parents' indexes.
     node_structure :
-        Tuple of :py:class:`pyhgf.typing.Indexes` with same length than number of node.
+        Tuple of :py:class:`pyhgf.typing.Indexes` with the same length as node number.
         For each node, the index list value and volatility parents.
     node_idx :
-        Pointer to the node that need to be updated. After continuous update, the
+        Pointer to the node that needs to be updated. After continuous updates, the
         parameters of value and volatility parents (if any) will be different.
 
     Returns
@@ -222,7 +222,7 @@ def binary_input_update(
 
         # TODO: this will be decided once we figure out the multi parents/children
         # # 1.1.2 Look at the (optional) va_pa's value parents (x3)
-        # # and update the driftrate accordingly
+        # # and update the drift rate accordingly
         # if va_pa_value_parents[0][1] is not None:
         #     for va_pa_va_pa in va_pa_value_parents[0][1]:
         #         # For each x2's value parents (optional)

--- a/pyhgf/continuous.py
+++ b/pyhgf/continuous.py
@@ -39,16 +39,16 @@ def continuous_node_update(
         following parameters: `"pihat", "pi", "muhat", "mu", "nu", "psis", "omega"` for
         continuous nodes.
     .. note::
-        `"psis"` is the value coupling strength. It should have same length than the
+        `"psis"` is the value coupling strength. It should have the same length as the
         volatility parents' indexes. `"kappas"` is the volatility coupling strength.
-        It should have same length than the volatility parents' indexes.
+        It should have the same length as the volatility parents' indexes.
     time_step :
-        Interval between the previous time point and the current time point.
+        The interval between the previous time point and the current time point.
     node_idx :
-        Pointer to the node that need to be updated. After continuous update, the
+        Pointer to the node that needs to be updated. After continuous updates, the
         parameters of value and volatility parents (if any) will be different.
     node_structure :
-        Tuple of :py:class:`pyhgf.typing.Indexes` with same length than number of node.
+        Tuple of :py:class:`pyhgf.typing.Indexes` with the same length as node number.
         For each node, the index list value and volatility parents.
 
     Returns
@@ -88,7 +88,7 @@ def continuous_node_update(
             # if this child is the last one relative to this parent's family, all the
             # child will update the parent at once, otherwise just pass and wait
             if node_structure[va_pa_idx].value_children[-1] == node_idx:
-                # unpack the parent's parameters with value and volatility parents
+                # unpack the parent's parameters with the value and volatility parents
                 va_pa_node_parameters = parameters_structure[va_pa_idx]
                 va_pa_value_parents_idx = node_structure[va_pa_idx].value_parents
                 va_pa_volatility_parents_idx = node_structure[
@@ -115,13 +115,13 @@ def continuous_node_update(
                     new_nu,
                 ]
 
-                # gather precision updates from other nodes if the parent has many child
-                # this part corresponds to the sum over children required for the
-                # multi-children situations
+                # gather precision updates from other nodes if the parent has many
+                # children - this part corresponds to the sum of children required for
+                # the multi-children situations
                 pi_children = 0.0
                 for child_idx in node_structure[va_pa_idx].value_children:
-                    # this part find which psi corresponds to this value parent
-                    # in a JAX compatible way
+                    # this part finds which psi corresponds to this value parent
+                    # in a JAX-compatible way
                     psi_child = jnp.where(
                         jnp.isin(
                             va_pa_idx,
@@ -145,20 +145,20 @@ def continuous_node_update(
                 driftrate = va_pa_node_parameters["rho"]
 
                 # Look at the (optional) va_pa's value parents
-                # and update driftrate accordingly
+                # and update drift rate accordingly
                 if va_pa_value_parents_idx is not None:
                     for va_pa_va_pa in va_pa_value_parents_idx:
                         driftrate += psi * va_pa_va_pa["mu"]
 
                 muhat_pa = va_pa_node_parameters["mu"] + time_step * driftrate
 
-                # gather PE updates from other nodes if the parent has many child
-                # this part corresponds to the sum over children required for the
+                # gather PE updates from other nodes if the parent has many children
+                # this part corresponds to the sum of children required for the
                 # multi-children situations
                 pe_children = 0.0
                 for child_idx in node_structure[va_pa_idx].value_children:
-                    # this part find which psi corresponds to this value parent
-                    # in a JAX compatible way
+                    # this part finds which psi corresponds to this value parent
+                    # in a JAX-compatible way
                     psi_child = jnp.where(
                         jnp.isin(
                             va_pa_idx,
@@ -231,7 +231,7 @@ def continuous_node_update(
             driftrate = vo_pa_node_parameters["rho"]
 
             # Look at the (optional) va_pa's value parents
-            # and update driftrate accordingly
+            # and update drift rate accordingly
             if vo_pa_value_parents_idx is not None:
                 for vo_pa_va_pa in vo_pa_value_parents_idx:
                     driftrate += psi * parameters_structure[vo_pa_va_pa]["mu"]
@@ -259,7 +259,7 @@ def continuous_input_update(
 ) -> Dict:
     """Update the input node structure.
 
-    This function is the entry level of the structure updates. It update the parent
+    This function is the entry-level of the structure updates. It updates the parent
     of the input node.
 
     Parameters
@@ -267,20 +267,20 @@ def continuous_input_update(
     value :
         The new observed value.
     time_step :
-        Interval between the previous time point and the current time point.
+        The interval between the previous time point and the current time point.
     parameters_structure :
         The structure of nodes' parameters. Each parameter is a dictionary with the
         following parameters: `"pihat", "pi", "muhat", "mu", "nu", "psis", "omega"` for
         continuous nodes.
     .. note::
-        `"psis"` is the value coupling strength. It should have same length than the
+        `"psis"` is the value coupling strength. It should have the same length as the
         volatility parents' indexes. `"kappas"` is the volatility coupling strength.
-        It should have same length than the volatility parents' indexes.
+        It should have the same length as the volatility parents' indexes.
     node_structure :
         Tuple of :py:class:`pyhgf.typing.Indexes` with same length than number of node.
         For each node, the index list value and volatility parents.
     node_idx :
-        Pointer to the node that need to be updated. After continuous update, the
+        Pointer to the node that needs to be updated. After continuous updates, the
         parameters of value and volatility parents (if any) will be different.
 
     Returns
@@ -353,7 +353,7 @@ def continuous_input_update(
         driftrate = va_pa_node_parameters["rho"]
 
         # Look at the (optional) va_pa's value parents
-        # and update driftrate accordingly
+        # and update drift rate accordingly
         if va_pa_value_parents_idx is not None:
             for va_pa_va_pa in va_pa_value_parents_idx:
                 driftrate += (
@@ -386,7 +386,7 @@ def gaussian_surprise(
 ) -> Array:
     r"""Surprise at an outcome under a Gaussian prediction.
 
-    The surprise ellicited by an observation :math:`x` under a Gaussian distribution
+    The surprise elicited by an observation :math:`x` under a Gaussian distribution
     with expected mean :math:`\hat{\mu}` and expected precision :math:`\hat{\pi}` is
     given by:
 

--- a/pyhgf/distribution.py
+++ b/pyhgf/distribution.py
@@ -64,7 +64,7 @@ def hgf_logp(
         The :math:`\omega` parameter, or *evolution rate*, at the third level of the
         HGF. This parameter represents the tonic part of the variance (the part that is
         not inherited from parents nodes). The value of this parameter will be ignored
-        when using a 2-levels HGF (`n_levels=2`).
+        when using a two-level HGF (`n_levels=2`).
     omega_input :
         Represent the noise associated with the input observation.
     rho_1 :
@@ -76,14 +76,14 @@ def hgf_logp(
     rho_3 :
         The :math:`\rho` parameter at the first level of the HGF. This parameter
         represents the drift of the random walk. The value of this parameter will be
-        ignored when using a 2-levels HGF (`n_levels=2`).
+        ignored when using a two-level HGF (`n_levels=2`).
     pi_1 :
         The :math:`\pi` parameter, or *precision*, at the first level of the HGF.
     pi_2 :
         The :math:`\pi` parameter, or *precision*, at the second level of the HGF.
     pi_3 :
         The :math:`\pi` parameter, or *precision*, at the third level of the HGF. The
-        value of this parameter will be ignored when using a 2-levels HGF
+        value of this parameter will be ignored when using a two-level HGF
         (`n_levels=2`).
     mu_1 :
         The :math:`\mu` parameter, or *mean*, at the first level of the HGF.
@@ -91,18 +91,18 @@ def hgf_logp(
         The :math:`\mu` parameter, or *mean*, at the second level of the HGF.
     mu_3 :
         The :math:`\mu` parameter, or *mean*, at the third level of the HGF. The value
-        of this parameter will be ignored when using a 2-levels HGF (`n_levels=2`).
+        of this parameter will be ignored when using a two-level HGF (`n_levels=2`).
     kappa_1 :
         The value of the :math:`\\kappa` parameter at the first level of the HGF. Kappa
         represents the phasic part of the variance (the part that is affected by the
-        parents nodes) and will defines the strenght of the connection between the node
+        parent nodes) and will define the strength of the connection between the node
         and the parent node. Often fixed to `1`.
     kappa_2 :
         The value of the :math:`\\kappa` parameter at the second level of the HGF. Kappa
         represents the phasic part of the variance (the part that is affected by the
-        parents nodes) and will defines the strenght of the connection between the node
+        parent nodes) and will define the strength of the connection between the node
         and the parent node. Often fixed to `1`. The value of this parameter will be
-        ignored when using a 2-levels HGF (`n_levels=2`).
+        ignored when using a two-level HGF (`n_levels=2`).
     input_data :
         List of input data. When `n` models should be fitted, the list contains `n` 1d
         Numpy arrays. By default, the associated time vector is the integers vector
@@ -113,19 +113,19 @@ def hgf_logp(
         The model type to use (can be "continuous" or "binary").
     n_levels :
         The number of hierarchies in the perceptual model (can be `2` or `3`). If
-        `None`, the nodes hierarchy is not created and might be provided afterward
+        `None`, the nodes hierarchy is not created and might be provided afterwards
         using :py:meth:`pyhgf.model.HGF.add_nodes`.
     response_function_parameters :
         Additional parameters to the response function.
     time_steps :
         List of 1d Numpy arrays containing the time vectors for each input time series.
-        If one of the list item is `None`, or if `None` is provided instead, the time
-        vector will defaults to unit vector.
+        If one of the list items is `None`, or if `None` is provided instead, the time
+        vector will default to the unit vector.
 
     Returns
     -------
     log_prob :
-        The sum of the log-probabilities (or negative surprise).
+        The sum of the log probabilities (or negative surprise).
 
     """
     # number of models
@@ -246,9 +246,9 @@ class HGFLogpGradOp(Op):
             vector. A different time vector can be passed to the `time_steps` argument.
         time_steps :
             List of 1d Numpy arrays containing the time_steps vectors for each input
-            time series. If one of the list item is `None`, or if `None` is provided
-            instead, the time_steps vector will defaults to integers vector starting at
-            0.
+            time series. If one of the list items is `None`, or if `None` is provided
+            instead, the time_steps vector will default to an integers vector starting
+            at 0.
         model_type :
             The model type to use (can be "continuous" or "binary").
         n_levels :
@@ -378,7 +378,7 @@ class HGFDistribution(Op):
     >>> timeserie = load_data("continuous")
 
     We create the PyMC distribution here, specifying the type of model and response
-    function we want to use (i.e simple gaussian surprise).
+    function we want to use (i.e. simple Gaussian surprise).
 
     >>> hgf_logp_op = HGFDistribution(
     >>>     n_levels=2,
@@ -387,7 +387,7 @@ class HGFDistribution(Op):
     >>> )
 
     Create the PyMC model
-    Here we are fixing all the paramters to arbitrary values and sampling the
+    Here we are fixing all the parameters to arbitrary values and sampling the
     posterior probability density of Omega in the second level, using a normal
     distribution as prior : ω_2 ~ N(-11, 2).
 
@@ -443,13 +443,13 @@ class HGFDistribution(Op):
             the `time_steps` argument.
         time_steps :
             List of 1d Numpy arrays containing the time_steps vectors for each input
-            time series. If one of the list item is `None`, or if `None` is provided
-            instead, the time vector will defaults to integers vector starting at 0.
+            time series. If one of the list items is `None`, or if `None` is provided
+            instead, the time vector will default to an integers vector starting at 0.
         model_type :
             The model type to use (can be "continuous" or "binary").
         n_levels :
             The number of hierarchies in the perceptual model (can be `2` or `3`). If
-            `None`, the nodes hierarchy is not created and might be provided afterward
+            `None`, the nodes hierarchy is not created and might be provided afterwards
             using `add_nodes()`.
         response_function :
             The response function to use to compute the model surprise.
@@ -516,7 +516,7 @@ class HGFDistribution(Op):
             pt.as_tensor_variable(kappa_1),
             pt.as_tensor_variable(kappa_2),
         ]
-        # Define the type of the output returned by the wrapped JAX function
+        # Define the type of output returned by the wrapped JAX function
         outputs = [pt.dscalar()]
         return Apply(self, inputs, outputs)
 
@@ -545,7 +545,7 @@ class HGFDistribution(Op):
             grad_kappa_2,
         ) = self.hgf_logp_grad_op(*inputs)
         # If there are inputs for which the gradients will never be needed or cannot
-        # be computed, `aesara.gradient.grad_not_implemented` should  be used as the
+        # be computed, `pytensor.gradient.grad_not_implemented` should  be used as the
         # output gradient for that input.
         output_gradient = output_gradients[0]
         return [

--- a/pyhgf/plots.py
+++ b/pyhgf/plots.py
@@ -30,19 +30,19 @@ def plot_trajectories(
     Parameters
     ----------
     hgf :
-        Instance of the HGF model.
+        An instance of the HGF model.
     ci :
-        Show the uncertainty aroud the values estimates (standard deviation).
+        Show the uncertainty around the values estimates (standard deviation).
     surprise :
-        If `True` plot each node's surprise together witt the sufficient statistics.
+        If `True` plot each node's surprise together with sufficient statistics.
         If `False`, only the input node's surprise is depicted.
     figsize :
         The width and height of the figure. Defaults to `(18, 9)` for a 2-levels model,
         or to `(18, 12)` for a 3-levels model.
     axs :
-        A list of Matplotlib axes instance where to draw the trajectories. This should
-        correspond to the number of nodes in the structure. Default is `None` (create a
-        new figure).
+        A list of Matplotlib axes instances where to draw the trajectories. This should
+        correspond to the number of nodes in the structure. The default is `None`
+        (create a new figure).
 
     Returns
     -------
@@ -139,10 +139,10 @@ def plot_trajectories(
             zorder=10,
         )
 
-    # loop over the node idexes
-    # -------------------------
+    # loop over the node indexes
+    # --------------------------
     for i in range(1, n_nodes + 1):
-        # use different colors for each nodes
+        # use different colors for each node
         color = next(palette)
 
         # which ax instance to use
@@ -239,12 +239,12 @@ def plot_correlations(hgf: "HGF") -> Axes:
     Parameters
     ----------
     hgf :
-        Instance of the HGF model.
+        An instance of the HGF model.
 
     Returns
     -------
     axs :
-        The Matplotlib ax instance containing the heatmap of parameters trajectories
+        The Matplotlib axe instance containing the heatmap of parameters trajectories
         correlation.
 
     """
@@ -288,7 +288,7 @@ def plot_network(hgf: "HGF") -> "Source":
     Parameters
     ----------
     hgf :
-        Instance of the HGF model containing a node structure.
+        An instance of the HGF model containing a node structure.
 
     Notes
     -----

--- a/pyhgf/response.py
+++ b/pyhgf/response.py
@@ -21,18 +21,18 @@ def first_level_gaussian_surprise(hgf: "HGF", response_function_parameters=None)
     Parameters
     ----------
     hgf :
-        Instance of the HGF model.
+        An instance of the HGF model.
     response_function_parameters :
         No additional parameters are required to compute the Gaussian surprise.
 
     Returns
     -------
     surprise :
-        The model surprise given the input data.
+        The model's surprise given the input data.
 
     """
     # compute the sum of Gaussian surprise at the first level
-    # the input value at time t is compared to the gaussian prediction at t-1
+    # the input value at time t is compared to the Gaussian prediction at t-1
     surprise = jnp.sum(
         gaussian_surprise(
             x=hgf.node_trajectories[0]["value"][1:],
@@ -48,7 +48,7 @@ def first_level_gaussian_surprise(hgf: "HGF", response_function_parameters=None)
 
 
 def total_gaussian_surprise(hgf: "HGF", response_function_parameters=None):
-    """Sum of the Gaussian surprise across probabilistic network.
+    """Sum of the Gaussian surprise across the probabilistic network.
 
     .. note::
       The function returns `jnp.inf` if the model could not fit at a given time point.
@@ -56,17 +56,17 @@ def total_gaussian_surprise(hgf: "HGF", response_function_parameters=None):
     Parameters
     ----------
     hgf :
-        Instance of the HGF model.
+        An instance of the HGF model.
     response_function_parameters :
         No additional parameters are required to compute the Gaussian surprise.
 
     Returns
     -------
     surprise :
-        The model surprise given the input data.
+        The model's surprise given the input data.
 
     """
-    # compute the sum of Gaussian surprise across every nodes
+    # compute the sum of Gaussian surprise across every node
     surprise = 0.0
 
     # first we start with nodes that are value parents to input nodes
@@ -111,14 +111,14 @@ def first_level_binary_surprise(hgf: "HGF", response_function_parameters=None):
     Parameters
     ----------
     hgf :
-        Instance of the HGF model.
+        An instance of the HGF model.
     response_function_parameters :
         No additional parameters are required to compute the binary surprise.
 
     Returns
     -------
     surprise :
-        The model surprise given the input data.
+        The model's surprise given the input data.
 
     """
     # Return an infinite surprise if the model cannot fit

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,6 +4,7 @@ import unittest
 from unittest import TestCase
 
 import jax.numpy as jnp
+import numpy as np
 
 from pyhgf import load_data
 from pyhgf.model import HGF
@@ -100,6 +101,35 @@ class Testmodel(TestCase):
         three_level_binary_hgf.input_data(input_data=timeseries)
         surprise = three_level_binary_hgf.surprise()
         assert jnp.isclose(surprise, 215.59067)
+
+        ############################
+        # dynamic update sequences #
+        ############################
+
+        three_level_binary_hgf = HGF(
+            n_levels=3,
+            model_type="binary",
+            initial_mu={"1": 0.0, "2": 0.5, "3": 0.0},
+            initial_pi={"1": 0.0, "2": 1e4, "3": 1e1},
+            omega={"1": None, "2": -6.0, "3": -2.0},
+            rho={"1": None, "2": 0.0, "3": 0.0},
+            kappas={"1": None, "2": 1.0},
+            eta0=0.0,
+            eta1=1.0,
+            pihat=jnp.inf,
+        )
+
+        # create a custom update series
+        update_sequence1 = three_level_binary_hgf.get_update_sequence()
+        update_sequence2 = update_sequence1[:2]
+        update_branches = (update_sequence1, update_sequence2)
+        branches_idx = np.random.binomial(n=1, p=0.5, size=len(timeseries))
+
+        three_level_binary_hgf.input_custom_sequence(
+            update_branches=update_branches,
+            branches_idx=branches_idx,
+            input_data=timeseries,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 import jax.numpy as jnp
 
 from pyhgf.continuous import continuous_input_update, continuous_node_update
-from pyhgf.structure import beliefs_propagation
+from pyhgf.structure import beliefs_propagation, list_branches, trim_sequence
 from pyhgf.typing import Indexes
 
 
@@ -66,6 +66,43 @@ class TestStructure(TestCase):
 
         assert new_parameters_structure[1]["mu"] == 0.6405112
         assert new_parameters_structure[2]["pi"] == 0.50698835
+
+    def test_find_branch(self):
+        """Test the find_branch function"""
+        node_structure = (
+            Indexes((1,), None, None, None),
+            Indexes(None, (2,), (0,), None),
+            Indexes(None, None, None, (1,)),
+            Indexes((4,), None, None, None),
+            Indexes(None, None, (3,), None),
+        )
+        branch_list = list_branches([0], node_structure, branch_list=[])
+        assert branch_list == [0, 1, 2]
+
+    def test_trim_sequence(self):
+        """Test the trim_sequence function"""
+        node_structure = (
+            Indexes((1,), None, None, None),
+            Indexes(None, (2,), (0,), None),
+            Indexes(None, None, None, (1,)),
+            Indexes((4,), None, None, None),
+            Indexes(None, None, (3,), None),
+        )
+        update_sequence = (
+            (0, continuous_input_update),
+            (1, continuous_node_update),
+            (2, continuous_node_update),
+            (3, continuous_node_update),
+            (4, continuous_node_update),
+        )
+        new_sequence = trim_sequence(
+            exclude_node_idxs=[0],
+            update_sequence=update_sequence,
+            node_structure=node_structure,
+        )
+        assert len(new_sequence) == 2
+        assert new_sequence[0][0] == 3
+        assert new_sequence[1][0] == 4
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds support to models with time-varying update sequences (which include situations of multiple input nodes that are not always receiving observations).