### PR TITLE
remove nu from the nodes attributes

### DIFF
--- a/src/pyhgf/model.py
+++ b/src/pyhgf/model.py
@@ -38,13 +38,13 @@ class HGF(object):
         The number of hierarchies in the model, including the input vector. Cannot be
         less than 2.
     edges :
-        A tuple of :py:class:`pyhgf.typing.Indexes` representing the nodes hierarchy.
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
     node_trajectories :
         The dynamic of the node's beliefs after updating.
     attributes :
-        The structure of nodes' parameters. Each parameter is a dictionary with the
-        following parameters: `"pihat", "pi", "muhat", "mu", "nu", "psis", "omega"` for
-        continuous nodes.
+        The attributes of the probabilistic nodes.
     .. note::
         The parameter structure also incorporate the value and volatility coupling
         strenght with children and parents (i.e. `"psis_parents"`, `"psis_children"`,
@@ -640,7 +640,6 @@ class HGF(object):
             "kappas_parents": None,
             "psis_children": tuple(value_coupling for _ in range(len(children_idxs))),
             "psis_parents": None,
-            "nu": 0.0,
             "omega": omega,
             "rho": rho,
         }
@@ -741,7 +740,6 @@ class HGF(object):
             "kappas_parents": None,
             "psis_children": None,
             "psis_parents": None,
-            "nu": 0.0,
             "omega": omega,
             "rho": rho,
         }

--- a/src/pyhgf/updates/binary.py
+++ b/src/pyhgf/updates/binary.py
@@ -29,9 +29,7 @@ def binary_node_prediction_error(
     Parameters
     ----------
     attributes :
-        The structure of nodes' parameters. Each parameter is a dictionary with the
-        following parameters: `"pihat", "pi", "muhat", "mu", "nu", "psis", "omega"` for
-        continuous nodes.
+        The attributes of the probabilistic nodes.
     .. note::
         The parameter structure also incorporate the value and volatility coupling
         strenght with children and parents (i.e. `"psis_parents"`, `"psis_children"`,
@@ -42,8 +40,9 @@ def binary_node_prediction_error(
         Pointer to the node that needs to be updated. After continuous updates, the
         parameters of value and volatility parents (if any) will be different.
     edges :
-        Tuple of :py:class:`pyhgf.typing.Indexes` with the same length as node number.
-        For each node, the index list value and volatility parents.
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
 
     Returns
     -------
@@ -75,14 +74,12 @@ def binary_node_prediction_error(
                 (
                     pi_value_parent,
                     mu_value_parent,
-                    nu_value_parent,
                 ) = prediction_error_value_parent(
                     attributes, edges, time_step, value_parent_idx
                 )
                 # 5. Update node's parameters and node's parents recursively
                 attributes[value_parent_idx]["pi"] = pi_value_parent
                 attributes[value_parent_idx]["mu"] = mu_value_parent
-                attributes[value_parent_idx]["nu"] = nu_value_parent
 
     return attributes
 
@@ -100,9 +97,7 @@ def binary_node_prediction(
     Parameters
     ----------
     attributes :
-        The structure of nodes' parameters. Each parameter is a dictionary with the
-        following parameters: `"pihat", "pi", "muhat", "mu", "nu", "psis", "omega"` for
-        continuous nodes.
+        The attributes of the probabilistic nodes.
     .. note::
         The parameter structure also incorporate the value and volatility coupling
         strenght with children and parents (i.e. `"psis_parents"`, `"psis_children"`,
@@ -113,8 +108,9 @@ def binary_node_prediction(
         Pointer to the node that needs to be updated. After continuous updates, the
         parameters of value and volatility parents (if any) will be different.
     edges :
-        Tuple of :py:class:`pyhgf.typing.Indexes` with the same length as node number.
-        For each node, the index list value and volatility parents.
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
 
     Returns
     -------
@@ -171,16 +167,15 @@ def binary_input_prediction_error(
     time_step :
         The interval between the previous time point and the current time point.
     attributes :
-        The structure of nodes' parameters. Each parameter is a dictionary with the
-        following parameters: `"pihat", "pi", "muhat", "mu", "nu", "psis", "omega"` for
-        continuous nodes.
+        The attributes of the probabilistic nodes.
     .. note::
         `"psis"` is the value coupling strength. It should have the same length as the
         volatility parents' indexes. `"kappas"` is the volatility coupling strength.
         It should have the same length as the volatility parents' indexes.
     edges :
-        Tuple of :py:class:`pyhgf.typing.Indexes` with the same length as node number.
-        For each node, the index list value and volatility parents.
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
     node_idx :
         Pointer to the node that needs to be updated. After continuous updates, the
         parameters of value and volatility parents (if any) will be different.
@@ -254,16 +249,15 @@ def binary_input_prediction(
     time_step :
         The interval between the previous time point and the current time point.
     attributes :
-        The structure of nodes' parameters. Each parameter is a dictionary with the
-        following parameters: `"pihat", "pi", "muhat", "mu", "nu", "psis", "omega"` for
-        continuous nodes.
+        The attributes of the probabilistic nodes.
     .. note::
         `"psis"` is the value coupling strength. It should have the same length as the
         volatility parents' indexes. `"kappas"` is the volatility coupling strength.
         It should have the same length as the volatility parents' indexes.
     edges :
-        Tuple of :py:class:`pyhgf.typing.Indexes` with the same length as node number.
-        For each node, the index list value and volatility parents.
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
     node_idx :
         Pointer to the node that needs to be updated. After continuous updates, the
         parameters of value and volatility parents (if any) will be different.

--- a/src/pyhgf/updates/categorical.py
+++ b/src/pyhgf/updates/categorical.py
@@ -33,16 +33,15 @@ def categorical_input_update(
     time_step :
         The interval between the previous time point and the current time point.
     attributes :
-        The structure of nodes' parameters. Each parameter is a dictionary with the
-        following parameters: `"pihat", "pi", "muhat", "mu", "nu", "psis", "omega"` for
-        continuous nodes.
+        The attributes of the probabilistic nodes.
     .. note::
         `"psis"` is the value coupling strength. It should have the same length as the
         volatility parents' indexes. `"kappas"` is the volatility coupling strength.
         It should have the same length as the volatility parents' indexes.
     edges :
-        Tuple of :py:class:`pyhgf.typing.Indexes` with the same length as node number.
-        For each node, the index list value and volatility parents.
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
     node_idx :
         Pointer to the node that needs to be updated.
 

--- a/src/pyhgf/updates/continuous.py
+++ b/src/pyhgf/updates/continuous.py
@@ -39,21 +39,21 @@ def continuous_node_prediction_error(
     Parameters
     ----------
     attributes :
-        The nodes' parameters.
+        The attributes of the probabilistic nodes.
     time_step :
         The interval between the previous time point and the current time point.
     node_idx :
         Pointer to the node that needs to be updated. After continuous updates, the
         parameters of value and volatility parents (if any) will be different.
     edges :
-        The edges of the network as a tuple of :py:class:`pyhgf.typing.Indexes` with
-        the same length as node number. For each node, the index list value and
-        volatility parents.
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
 
     Returns
     -------
     attributes :
-        The updated nodes' parameters.
+        The updated attributes of the probabilistic nodes.
 
     See Also
     --------
@@ -82,18 +82,13 @@ def continuous_node_prediction_error(
             # if this child is the last one relative to this parent's family, all the
             # children will update the parent at once, otherwise just pass and wait
             if edges[value_parent_idx].value_children[-1] == node_idx:
-                (
-                    pi_value_parent,
-                    mu_value_parent,
-                    nu_value_parent,
-                ) = prediction_error_value_parent(
+                (pi_value_parent, mu_value_parent) = prediction_error_value_parent(
                     attributes, edges, time_step, value_parent_idx
                 )
 
                 # Update this parent's parameters
                 attributes[value_parent_idx]["pi"] = pi_value_parent
                 attributes[value_parent_idx]["mu"] = mu_value_parent
-                attributes[value_parent_idx]["nu"] = nu_value_parent
 
     #############################
     # Update volatility parents #
@@ -106,7 +101,6 @@ def continuous_node_prediction_error(
                 (
                     pi_volatility_parent,
                     mu_volatility_parent,
-                    nu_volatility_parent,
                 ) = prediction_error_volatility_parent(
                     attributes, edges, time_step, volatility_parent_idx
                 )
@@ -114,7 +108,6 @@ def continuous_node_prediction_error(
                 # Update this parent's parameters
                 attributes[volatility_parent_idx]["pi"] = pi_volatility_parent
                 attributes[volatility_parent_idx]["mu"] = mu_volatility_parent
-                attributes[volatility_parent_idx]["nu"] = nu_volatility_parent
 
     return attributes
 
@@ -140,9 +133,7 @@ def continuous_node_prediction(
     Parameters
     ----------
     attributes :
-        The structure of nodes' parameters. Each parameter is a dictionary with the
-        following parameters: `"pihat", "pi", "muhat", "mu", "nu", "psis", "omega"` for
-        continuous nodes.
+        The attributes of the probabilistic nodes.
     .. note::
         The parameter structure also incorporate the value and volatility coupling
         strenght with children and parents (i.e. `"psis_parents"`, `"psis_children"`,
@@ -153,13 +144,14 @@ def continuous_node_prediction(
         Pointer to the node that needs to be updated. After continuous updates, the
         parameters of value and volatility parents (if any) will be different.
     edges :
-        Tuple of :py:class:`pyhgf.typing.Indexes` with the same length as node number.
-        For each node, the index list value and volatility parents.
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
 
     Returns
     -------
     attributes :
-        The updated parameters structure.
+        The updated attributes of the probabilistic nodes.
 
     See Also
     --------
@@ -232,16 +224,15 @@ def continuous_input_prediction_error(
     time_step :
         The interval between the previous time point and the current time point.
     attributes :
-        The structure of nodes' parameters. Each parameter is a dictionary with the
-        following parameters: `"pihat", "pi", "muhat", "mu", "nu", "omega"` for
-        continuous nodes.
+        The attributes of the probabilistic nodes.
     .. note::
         The parameter structure also incorporate the value and volatility coupling
         strenght with children and parents (i.e. `"psis_parents"`, `"psis_children"`,
         `"kappas_parents"`, `"kappas_children"`).
     edges :
-        Tuple of :py:class:`pyhgf.typing.Indexes` with same length than number of node.
-        For each node, the index list value and volatility parents.
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
     node_idx :
         Pointer to the node that needs to be updated. After continuous updates, the
         parameters of value and volatility parents (if any) will be different.
@@ -249,7 +240,7 @@ def continuous_input_prediction_error(
     Returns
     -------
     attributes :
-        The updated parameters structure.
+        The updated attributes of the probabilistic nodes.
 
     See Also
     --------
@@ -279,7 +270,6 @@ def continuous_input_prediction_error(
             if edges[value_parent_idx].value_children[-1] == node_idx:
                 (
                     pi_value_parent,
-                    nu_value_parent,
                     mu_value_parent,
                 ) = prediction_error_input_value_parent(
                     attributes, edges, time_step, value_parent_idx
@@ -288,7 +278,6 @@ def continuous_input_prediction_error(
                 # update input node's parameters
                 attributes[value_parent_idx]["pi"] = pi_value_parent
                 attributes[value_parent_idx]["mu"] = mu_value_parent
-                attributes[value_parent_idx]["nu"] = nu_value_parent
 
     return attributes
 
@@ -313,16 +302,15 @@ def continuous_input_prediction(
     time_step :
         The interval between the previous time point and the current time point.
     attributes :
-        The structure of nodes' parameters. Each parameter is a dictionary with the
-        following parameters: `"pihat", "pi", "muhat", "mu", "nu", "omega"` for
-        continuous nodes.
+        The attributes of the probabilistic nodes.
     .. note::
         The parameter structure also incorporate the value and volatility coupling
         strenght with children and parents (i.e. `"psis_parents"`, `"psis_children"`,
         `"kappas_parents"`, `"kappas_children"`).
     edges :
-        Tuple of :py:class:`pyhgf.typing.Indexes` with same length than number of node.
-        For each node, the index list value and volatility parents.
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
     node_idx :
         Pointer to the node that needs to be updated. After continuous updates, the
         parameters of value and volatility parents (if any) will be different.
@@ -330,7 +318,7 @@ def continuous_input_prediction(
     Returns
     -------
     attributes :
-        The updated parameters structure.
+        The updated attributes of the probabilistic nodes.
 
     See Also
     --------

--- a/src/pyhgf/updates/prediction/binary.py
+++ b/src/pyhgf/updates/prediction/binary.py
@@ -17,6 +17,27 @@ def prediction_mean_value_parent(
     time_step: float,
     value_parent_idx: int,
 ) -> Array:
+    r"""Expected value for the mean of the value parent.
+
+    Parameters
+    ----------
+    attributes :
+        The attributes of the probabilistic nodes.
+    edges :
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
+    time_step :
+        The interval between the previous time point and the current time point.
+    value_parent_idx :
+        Pointer to the node that will be updated.
+
+    Returns
+    -------
+    muhat_value_parent :
+        The expected value for the mean of the value parent (:math:`\\hat{\\mu}`).
+
+    """
     value_parent_value_parent_idxs = edges[value_parent_idx].value_parents
 
     # drift rate
@@ -39,6 +60,27 @@ def prediction_mean_value_parent(
 def prediction_precision_value_parent(
     attributes: Dict, edges: Edges, time_step: float, value_parent_idx: int
 ) -> Array:
+    r"""Expected value for the precision of the value parent.
+
+    Parameters
+    ----------
+    attributes :
+        The attributes of the probabilistic nodes.
+    edges :
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
+    time_step :
+        The interval between the previous time point and the current time point.
+    value_parent_idx :
+        Pointer to the node that will be updated.
+
+    Returns
+    -------
+    pihat_value_parent :
+        The expected value for the mean of the value parent (:math:`\\hat{\\pi}`).
+
+    """
     value_parent_volatility_parent_idxs = edges[value_parent_idx].volatility_parents
 
     # get log volatility
@@ -80,11 +122,11 @@ def prediction_value_parent(
     Parameters
     ----------
     attributes :
-        The nodes' parameters.
+        The attributes of the probabilistic nodes.
     edges :
-        The edges of the network as a tuple of :py:class:`pyhgf.typing.Indexes` with
-        the same length as node number. For each node, the index list value and
-        volatility parents.
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
     time_step :
         The interval between the previous time point and the current time point.
     value_parent_idx :
@@ -115,16 +157,16 @@ def prediction_input_value_parent(
     time_step: float,
     value_parent_idx: int,
 ) -> Tuple[Array, ...]:
-    """Prediction step for the value parent(s) of a binary input node.
+    r"""Prediction step for the value parent(s) of a binary input node.
 
     Parameters
     ----------
     attributes :
-        The nodes' parameters.
+        The attributes of the probabilistic nodes.
     edges :
-        The edges of the network as a tuple of :py:class:`pyhgf.typing.Indexes` with
-        the same length as node number. For each node, the index list value and
-        volatility parents.
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
     time_step :
         The interval between the previous time point and the current time point.
     value_parent_idx :

--- a/src/pyhgf/updates/prediction/continuous.py
+++ b/src/pyhgf/updates/prediction/continuous.py
@@ -16,6 +16,27 @@ def prediction_mean_value_parent(
     time_step: float,
     value_parent_idx: int,
 ) -> Array:
+    r"""Expected value for the mean of the value parent.
+
+    Parameters
+    ----------
+    attributes :
+        The attributes of the probabilistic nodes.
+    edges :
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
+    time_step :
+        The interval between the previous time point and the current time point.
+    value_parent_idx :
+        Pointer to the node that will be updated.
+
+    Returns
+    -------
+    muhat_value_parent :
+        The expected value for the mean of the value parent (:math:`\\hat{\\mu}`).
+
+    """
     # list the value and volatility parents
     value_parent_value_parents_idxs = edges[value_parent_idx].value_parents
 
@@ -40,6 +61,27 @@ def prediction_mean_value_parent(
 def prediction_precision_value_parent(
     attributes: Dict, edges: Edges, time_step: float, value_parent_idx: int
 ) -> Array:
+    r"""Expected value for the precision of the value parent.
+
+    Parameters
+    ----------
+    attributes :
+        The attributes of the probabilistic nodes.
+    edges :
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
+    time_step :
+        The interval between the previous time point and the current time point.
+    value_parent_idx :
+        Pointer to the node that will be updated.
+
+    Returns
+    -------
+    pihat_value_parent :
+        The expected value for the mean of the value parent (:math:`\\hat{\\pi}`).
+
+    """
     # list the value and volatility parents
     value_parent_volatility_parents_idxs = edges[value_parent_idx].volatility_parents
 
@@ -82,11 +124,11 @@ def prediction_value_parent(
     Parameters
     ----------
     attributes :
-        The nodes' parameters.
+        The attributes of the probabilistic nodes.
     edges :
-        The edges of the network as a tuple of :py:class:`pyhgf.typing.Indexes` with
-        the same length as node number. For each node, the index list value and
-        volatility parents.
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
     time_step :
         The interval between the previous time point and the current time point.
     value_parent_idx :
@@ -173,7 +215,7 @@ def prediction_volatility_parent(
     time_step: float,
     volatility_parent_idx: int,
 ) -> Tuple[Array, ...]:
-    """Prediction step for the volatility parent(s) of a continuous node.
+    r"""Prediction step for the volatility parent(s) of a continuous node.
 
     Updating the posterior distribution of the volatility parent is a two-step process:
     1. Update the posterior precision using
@@ -184,11 +226,11 @@ def prediction_volatility_parent(
     Parameters
     ----------
     attributes :
-        The nodes' parameters.
+        The attributes of the probabilistic nodes.
     edges :
-        The edges of the network as a tuple of :py:class:`pyhgf.typing.Indexes` with
-        the same length as node number. For each node, the index list value and
-        volatility parents.
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
     time_step :
         The interval between the previous time point and the current time point.
     volatility_parent_idx :

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -65,7 +65,6 @@ class Testbinary(TestCase):
             "kappas_parents": None,
             "kappas_children": None,
             "mu": 1.0,
-            "nu": 1.0,
             "omega": 1.0,
             "rho": 0.0,
         }
@@ -78,7 +77,6 @@ class Testbinary(TestCase):
             "kappas_parents": (1.0,),
             "kappas_children": None,
             "mu": 1.0,
-            "nu": 1.0,
             "omega": 1.0,
             "rho": 0.0,
         }
@@ -91,7 +89,6 @@ class Testbinary(TestCase):
             "kappas_parents": None,
             "kappas_children": (1.0,),
             "mu": 1.0,
-            "nu": 1.0,
             "omega": 1.0,
             "rho": 0.0,
         }
@@ -138,13 +135,13 @@ class Testbinary(TestCase):
         for idx, val in zip(["mu", "muhat", "pihat"], [1.0, 0.7310586, 5.0861616]):
             assert jnp.isclose(new_attributes[1][idx], val)
         for idx, val in zip(
-            ["mu", "muhat", "pi", "pihat", "nu"],
-            [1.8515793, 1.0, 0.31581485, 0.11920292, 7.389056],
+            ["mu", "muhat", "pi", "pihat"],
+            [1.8515793, 1.0, 0.31581485, 0.11920292],
         ):
             assert jnp.isclose(new_attributes[2][idx], val)
         for idx, val in zip(
-            ["mu", "muhat", "pi", "pihat", "nu"],
-            [0.5611493, 1.0, 0.5380009, 0.26894143, 2.7182817],
+            ["mu", "muhat", "pi", "pihat"],
+            [0.5611493, 1.0, 0.5380009, 0.26894143],
         ):
             assert jnp.isclose(new_attributes[3][idx], val)
 
@@ -169,13 +166,11 @@ class Testbinary(TestCase):
         for idx, val in zip(["mu", "muhat", "pihat"], [0.0, 0.9571387, 24.37586]):
             assert jnp.isclose(last[1][idx], val)
         for idx, val in zip(
-            ["mu", "muhat", "pi", "pihat", "nu"],
-            [-2.358439, 3.1059794, 0.17515838, 0.13413419, 2.1602433],
+            ["mu", "muhat", "pi", "pihat"],
+            [-2.358439, 3.1059794, 0.17515838, 0.13413419],
         ):
             assert jnp.isclose(last[2][idx], val)
-        for idx, val in zip(
-            ["muhat", "pihat", "nu"], [-0.22977911, 0.14781797, 2.7182817]
-        ):
+        for idx, val in zip(["muhat", "pihat"], [-0.22977911, 0.14781797]):
             assert jnp.isclose(last[3][idx], val)
 
 

--- a/tests/test_continuous.py
+++ b/tests/test_continuous.py
@@ -39,7 +39,6 @@ class Testcontinuous(TestCase):
             "kappas_parents": None,
             "kappas_children": None,
             "mu": 1.0,
-            "nu": 1.0,
             "omega": 1.0,
             "rho": 0.0,
         }
@@ -52,7 +51,6 @@ class Testcontinuous(TestCase):
             "kappas_parents": None,
             "kappas_children": None,
             "mu": 1.0,
-            "nu": 1.0,
             "omega": 1.0,
             "rho": 0.0,
         }
@@ -113,7 +111,6 @@ class Testcontinuous(TestCase):
             "kappas_parents": (1.0,),
             "kappas_children": None,
             "mu": 1.0,
-            "nu": 1.0,
             "omega": 1.0,
             "rho": 0.0,
         }
@@ -126,7 +123,6 @@ class Testcontinuous(TestCase):
             "kappas_parents": None,
             "kappas_children": (1.0,),
             "mu": 1.0,
-            "nu": 1.0,
             "omega": 1.0,
             "rho": 0.0,
         }
@@ -161,13 +157,13 @@ class Testcontinuous(TestCase):
         for idx, val in zip(["time_step", "value"], [1.0, 0.2]):
             assert jnp.isclose(new_attributes[0][idx], val)
         for idx, val in zip(
-            ["pi", "pihat", "mu", "muhat", "nu"],
-            [10000.119, 0.11920292, 0.20000952, 1.0, 7.389056],
+            ["pi", "pihat", "mu", "muhat"],
+            [10000.119, 0.11920292, 0.20000952, 1.0],
         ):
             assert jnp.isclose(new_attributes[1][idx], val)
         for idx, val in zip(
-            ["pi", "pihat", "mu", "muhat", "nu"],
-            [0.29854316, 0.26894143, -0.36260414, 1.0, 2.7182817],
+            ["pi", "pihat", "mu", "muhat"],
+            [0.29854316, 0.26894143, -0.36260414, 1.0],
         ):
             assert jnp.isclose(new_attributes[2][idx], val)
 
@@ -197,7 +193,6 @@ class Testcontinuous(TestCase):
             "kappas_parents": (1.0,),
             "kappas_children": None,
             "mu": 1.0,
-            "nu": 1.0,
             "omega": -3.0,
             "rho": 0.0,
         }
@@ -210,7 +205,6 @@ class Testcontinuous(TestCase):
             "kappas_parents": None,
             "kappas_children": (1.0,),
             "mu": 1.0,
-            "nu": 1.0,
             "omega": -3.0,
             "rho": 0.0,
         }
@@ -245,13 +239,13 @@ class Testcontinuous(TestCase):
         for idx, val in zip(["time_step", "value"], [1.0, 0.8241]):
             assert jnp.isclose(last[0][idx], val)
         for idx, val in zip(
-            ["pi", "pihat", "mu", "muhat", "nu"],
-            [22792.508, 12792.507, 0.80494785, 0.7899765, 3.3479002e-05],
+            ["pi", "pihat", "mu", "muhat"],
+            [22792.508, 12792.507, 0.80494785, 0.7899765],
         ):
             assert jnp.isclose(last[1][idx], val)
         for idx, val in zip(
-            ["pi", "pihat", "mu", "muhat", "nu"],
-            [1.4523009, 1.4297459, -6.9464974, -7.3045917, 0.049787067],
+            ["pi", "pihat", "mu", "muhat"],
+            [1.4523009, 1.4297459, -6.9464974, -7.3045917],
         ):
             assert jnp.isclose(last[2][idx], val)
 

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -145,7 +145,7 @@ class TestDistribution(TestCase):
             np.array(0.0),
         )
 
-        assert jnp.isclose(omega_1, -7.9174647)
+        assert jnp.isclose(omega_1, -7.9172916)
 
         ##############
         # Binary HGF #
@@ -308,7 +308,7 @@ class TestDistribution(TestCase):
             kappa_1=1.0,
         )[0].eval()
 
-        assert jnp.isclose(omega_1, -7.9174647)
+        assert jnp.isclose(omega_1, -7.9172916)
 
         ##############
         # Binary HGF #

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -37,7 +37,6 @@ class TestStructure(TestCase):
             "kappas_parents": (1.0,),
             "kappas_children": None,
             "mu": 1.0,
-            "nu": 1.0,
             "omega": -3.0,
             "rho": 0.0,
         }
@@ -50,7 +49,6 @@ class TestStructure(TestCase):
             "kappas_parents": None,
             "kappas_children": (1.0,),
             "mu": 1.0,
-            "nu": 1.0,
             "omega": -3.0,
             "rho": 0.0,
         }


### PR DESCRIPTION
- Remove the variable nu from the node's attributes. The variable is computed internally by the update function.
- Add docstrings for the update functions and uniformize the parameter descriptions.
This will close #96.