### PR TITLE
prediction update only apply to the target node

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -27,7 +27,6 @@ Core functionnalities to update *binary* nodes.
     binary_node_prediction_error
     binary_node_prediction
     binary_input_prediction_error
-    binary_input_prediction
 
 Updating continuous nodes
 =========================
@@ -42,7 +41,6 @@ Core functionnalities to update *continuous* nodes.
     continuous_node_prediction_error
     continuous_node_prediction
     continuous_input_prediction_error
-    continuous_input_prediction
 
 Updating categorical nodes
 ==========================

--- a/src/pyhgf/updates/binary.py
+++ b/src/pyhgf/updates/binary.py
@@ -6,8 +6,7 @@ from typing import Dict
 from jax import jit
 
 from pyhgf.typing import Edges
-from pyhgf.updates.continuous import predict_mean, predict_precision
-from pyhgf.updates.prediction.binary import predict_input_value_parent
+from pyhgf.updates.prediction.binary import predict_binary_state_node
 from pyhgf.updates.prediction_error.binary import (
     prediction_error_input_value_parent,
     prediction_error_value_parent,
@@ -84,11 +83,7 @@ def binary_node_prediction_error(
 def binary_node_prediction(
     attributes: Dict, time_step: float, node_idx: int, edges: Edges, **args
 ) -> Dict:
-    """Update the value parent(s) of a binary node.
-
-    In a three-level HGF, this step will update the node :math:`x_2`.
-
-    Then returns the new node tuple `(parameters, value_parents, volatility_parents)`.
+    """Update the expected mean and precision of a binary state node.
 
     Parameters
     ----------
@@ -111,7 +106,7 @@ def binary_node_prediction(
     Returns
     -------
     attributes :
-        The updated node structure.
+        The new node structure with updated mean and expected precision.
 
     References
     ----------
@@ -120,28 +115,12 @@ def binary_node_prediction(
        arXiv. https://doi.org/10.48550/ARXIV.2305.10937
 
     """
-    # using the current node index, unwrap parameters and parents
-    value_parent_idxs = edges[node_idx].value_parents
+    # Get the new expected value for the mean and precision
+    pihat, muhat = predict_binary_state_node(attributes, edges, time_step, node_idx)
 
-    # Return here if no parents node are found
-    if value_parent_idxs is None:
-        return attributes
-
-    ################################################################
-    # Update the predictions of the continuous value parents (x-2) #
-    ################################################################
-    if value_parent_idxs is not None:
-        for value_parent_idx in value_parent_idxs:
-            pihat_value_parent = predict_precision(
-                attributes, edges, time_step, value_parent_idx
-            )
-            muhat_value_parent = predict_mean(
-                attributes, edges, time_step, value_parent_idx
-            )
-
-            # update the parent nodes' parameters
-            attributes[value_parent_idx]["pihat"] = pihat_value_parent
-            attributes[value_parent_idx]["muhat"] = muhat_value_parent
+    # Update the node's attributes
+    attributes[node_idx]["pihat"] = pihat
+    attributes[node_idx]["muhat"] = muhat
 
     return attributes
 
@@ -222,77 +201,5 @@ def binary_input_prediction_error(
             attributes[value_parent_idx]["mu"] = mu_value_parent
 
     attributes[node_idx]["surprise"] = surprise
-
-    return attributes
-
-
-@partial(jit, static_argnames=("edges", "node_idx"))
-def binary_input_prediction(
-    attributes: Dict,
-    time_step: float,
-    node_idx: int,
-    edges: Edges,
-    value: float,
-) -> Dict:
-    """Update the input node structure given one binary observation.
-
-    This function is the entry-level of the binary node. It updates the parents of
-    the input node (:math:`x_1`).
-
-    Parameters
-    ----------
-    value :
-        The new observed value.
-    time_step :
-        The interval between the previous time point and the current time point.
-    attributes :
-        The attributes of the probabilistic nodes.
-    .. note::
-        `"psis"` is the value coupling strength. It should have the same length as the
-        volatility parents' indexes. `"kappas"` is the volatility coupling strength.
-        It should have the same length as the volatility parents' indexes.
-    edges :
-        The edges of the probabilistic nodes as a tuple of
-        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
-        For each node, the index list value and volatility parents and children.
-    node_idx :
-        Pointer to the node that needs to be updated. After continuous updates, the
-        parameters of value and volatility parents (if any) will be different.
-
-    Returns
-    -------
-    attributes :
-        The updated parameters structure.
-
-    See Also
-    --------
-    update_continuous_parents, update_continuous_input_parents
-
-    References
-    ----------
-    .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
-       Mathys, C. (2023). The generalized Hierarchical Gaussian Filter (Version 1).
-       arXiv. https://doi.org/10.48550/ARXIV.2305.10937
-
-    """
-    # list value and volatility parents
-    value_parent_idxs = edges[node_idx].value_parents
-    volatility_parent_idxs = edges[node_idx].volatility_parents
-
-    if (value_parent_idxs is None) and (volatility_parent_idxs is None):
-        return attributes
-
-    #######################################################
-    # Update the value parent(s) of the binary input node #
-    #######################################################
-    if value_parent_idxs is not None:
-        for value_parent_idx in value_parent_idxs:
-            pihat_value_parent, muhat_value_parent = predict_input_value_parent(
-                attributes, edges, time_step, value_parent_idx
-            )
-
-            # Update value parent's parameters
-            attributes[value_parent_idx]["pihat"] = pihat_value_parent
-            attributes[value_parent_idx]["muhat"] = muhat_value_parent
 
     return attributes

--- a/src/pyhgf/updates/continuous.py
+++ b/src/pyhgf/updates/continuous.py
@@ -125,19 +125,7 @@ def continuous_node_prediction_error(
 def continuous_node_prediction(
     attributes: Dict, time_step: float, node_idx: int, edges: Edges, **args
 ) -> Dict:
-    """Prediction step for the value and volatility parents of a continuous node.
-
-    Updating the node's parents is a two-step process:
-    1. Update value parent(s).
-    2. Update volatility parent(s).
-
-    If a value/volatility parent has multiple children, all the children will update
-    the parent together, therefor this function should only be called once per group
-    of child nodes. The method :py:meth:`pyhgf.model.HGF.get_update_sequence`
-    ensures that this function is only called once all the children have been
-    updated.
-
-    Then returns the structure of the new parameters.
+    """Update the expected mean and precision of a continuous node.
 
     Parameters
     ----------
@@ -150,8 +138,7 @@ def continuous_node_prediction(
     time_step :
         The interval between the previous time point and the current time point.
     node_idx :
-        Pointer to the node that needs to be updated. After continuous updates, the
-        parameters of value and volatility parents (if any) will be different.
+        Pointer to the node that will be updated.
     edges :
         The edges of the probabilistic nodes as a tuple of
         :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
@@ -173,45 +160,14 @@ def continuous_node_prediction(
        arXiv. https://doi.org/10.48550/ARXIV.2305.10937
 
     """
-    # list value and volatility parents
-    value_parents_idxs = edges[node_idx].value_parents
-    volatility_parents_idxs = edges[node_idx].volatility_parents
+    # Get the new expected mean
+    muhat = predict_mean(attributes, edges, time_step, node_idx)
+    # Get the new expected precision
+    pihat = predict_precision(attributes, edges, time_step, node_idx)
 
-    # return here if no parents node are provided
-    if (value_parents_idxs is None) and (volatility_parents_idxs is None):
-        return attributes
-
-    ########################
-    # Update value parents #
-    ########################
-    if value_parents_idxs is not None:
-        for value_parent_idx in value_parents_idxs:
-            muhat_value_parent = predict_mean(
-                attributes, edges, time_step, value_parent_idx
-            )
-            pihat_value_parent = predict_precision(
-                attributes, edges, time_step, value_parent_idx
-            )
-
-            # Update this parent's parameters
-            attributes[value_parent_idx]["pihat"] = pihat_value_parent
-            attributes[value_parent_idx]["muhat"] = muhat_value_parent
-
-    #############################
-    # Update volatility parents #
-    #############################
-    if volatility_parents_idxs is not None:
-        for volatility_parent_idx in volatility_parents_idxs:
-            muhat_volatility_parent = predict_mean(
-                attributes, edges, time_step, volatility_parent_idx
-            )
-            pihat_volatility_parent = predict_precision(
-                attributes, edges, time_step, volatility_parent_idx
-            )
-
-            # Update this parent's parameters
-            attributes[volatility_parent_idx]["pihat"] = pihat_volatility_parent
-            attributes[volatility_parent_idx]["muhat"] = muhat_volatility_parent
+    # Update this node's parameters
+    attributes[node_idx]["pihat"] = pihat
+    attributes[node_idx]["muhat"] = muhat
 
     return attributes
 
@@ -292,82 +248,5 @@ def continuous_input_prediction_error(
                 # update input node's parameters
                 attributes[value_parent_idx]["pi"] = pi_value_parent
                 attributes[value_parent_idx]["mu"] = mu_value_parent
-
-    return attributes
-
-
-@partial(jit, static_argnames=("edges", "node_idx"))
-def continuous_input_prediction(
-    attributes: Dict,
-    time_step: float,
-    node_idx: int,
-    edges: Edges,
-    value: float,
-) -> Dict:
-    """Update the input node structure.
-
-    This function is the entry-level of the structure updates. It updates the parent
-    of the input node.
-
-    Parameters
-    ----------
-    value :
-        The new observed value.
-    time_step :
-        The interval between the previous time point and the current time point.
-    attributes :
-        The attributes of the probabilistic nodes.
-    .. note::
-        The parameter structure also incorporate the value and volatility coupling
-        strenght with children and parents (i.e. `"psis_parents"`, `"psis_children"`,
-        `"kappas_parents"`, `"kappas_children"`).
-    edges :
-        The edges of the probabilistic nodes as a tuple of
-        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
-        For each node, the index list value and volatility parents and children.
-    node_idx :
-        Pointer to the node that needs to be updated. After continuous updates, the
-        parameters of value and volatility parents (if any) will be different.
-
-    Returns
-    -------
-    attributes :
-        The updated attributes of the probabilistic nodes.
-
-    See Also
-    --------
-    continuous_node_update, update_binary_input_parents
-
-    References
-    ----------
-    .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
-       Mathys, C. (2023). The generalized Hierarchical Gaussian Filter (Version 1).
-       arXiv. https://doi.org/10.48550/ARXIV.2305.10937
-
-    """
-    # store timestep in the node's parameters
-    attributes[node_idx]["time_step"] = time_step
-
-    # list value and volatility parents
-    value_parents_idxs = edges[node_idx].value_parents
-
-    ########################
-    # Update value parents #
-    ########################
-    if value_parents_idxs is not None:
-        for value_parent_idx in value_parents_idxs:
-            # if this child is the last one relative to this parent's family, all the
-            # children will update the parent at once, otherwise just pass and wait
-            if edges[value_parent_idx].value_children[-1] == node_idx:
-                muhat_value_parent = predict_mean(
-                    attributes, edges, time_step, value_parent_idx
-                )
-                pihat_value_parent = predict_precision(
-                    attributes, edges, time_step, value_parent_idx
-                )
-
-                # update input node's parameters
-                attributes[value_parent_idx]["pihat"] = pihat_value_parent
-                attributes[value_parent_idx]["muhat"] = muhat_value_parent
 
     return attributes

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -12,7 +12,6 @@ from pyhgf.math import binary_surprise, gaussian_density, sigmoid
 from pyhgf.networks import beliefs_propagation
 from pyhgf.typing import Indexes
 from pyhgf.updates.binary import (
-    binary_input_prediction,
     binary_input_prediction_error,
     binary_node_prediction,
     binary_node_prediction_error,
@@ -107,9 +106,9 @@ class Testbinary(TestCase):
         )
 
         # create update sequence
-        sequence1 = 0, binary_input_prediction
-        sequence2 = 1, binary_node_prediction
-        sequence3 = 2, continuous_node_prediction
+        sequence1 = 3, continuous_node_prediction
+        sequence2 = 2, continuous_node_prediction
+        sequence3 = 1, binary_node_prediction
         sequence4 = 0, binary_input_prediction_error
         sequence5 = 1, binary_node_prediction_error
         sequence6 = 2, continuous_node_prediction_error

--- a/tests/test_continuous.py
+++ b/tests/test_continuous.py
@@ -12,7 +12,6 @@ from pyhgf.math import gaussian_surprise
 from pyhgf.networks import beliefs_propagation
 from pyhgf.typing import Indexes
 from pyhgf.updates.continuous import (
-    continuous_input_prediction,
     continuous_input_prediction_error,
     continuous_node_prediction,
     continuous_node_prediction_error,
@@ -69,9 +68,8 @@ class Testcontinuous(TestCase):
         ###########################################
         # No value parent - no volatility parents #
         ###########################################
-        sequence1 = 0, continuous_input_prediction
-        sequence2 = 0, continuous_input_prediction_error
-        update_sequence = (sequence1, sequence2)
+        sequence1 = 0, continuous_input_prediction_error
+        update_sequence = (sequence1,)
         new_attributes, _ = beliefs_propagation(
             attributes=attributes,
             edges=edges,
@@ -139,8 +137,8 @@ class Testcontinuous(TestCase):
         )
 
         # create update sequence
-        sequence1 = 0, continuous_input_prediction
-        sequence2 = 1, continuous_node_prediction
+        sequence1 = 1, continuous_node_prediction
+        sequence2 = 2, continuous_node_prediction
         sequence3 = 0, continuous_input_prediction_error
         sequence4 = 1, continuous_node_prediction_error
         update_sequence = (sequence1, sequence2, sequence3, sequence4)
@@ -221,8 +219,8 @@ class Testcontinuous(TestCase):
         )
 
         # create update sequence
-        sequence1 = 0, continuous_input_prediction
-        sequence2 = 1, continuous_node_prediction
+        sequence1 = 1, continuous_node_prediction
+        sequence2 = 2, continuous_node_prediction
         sequence3 = 0, continuous_input_prediction_error
         sequence4 = 1, continuous_node_prediction_error
         update_sequence = (sequence1, sequence2, sequence3, sequence4)


### PR DESCRIPTION
Prediction steps used to update the parents of the target nodes. They are now only updating the target node's expectations. The update sequences are generated accordingly.

Close #97 