### PR TITLE
use Adam in vectorised deep networks and make it default

### DIFF
--- a/pyhgf/model/vectorized_deep_network.py
+++ b/pyhgf/model/vectorized_deep_network.py
@@ -93,6 +93,7 @@ class VectorizedDeepNetwork:
         self.predictions: Optional[jnp.ndarray] = None
         self._propagation_fn: Optional[Callable] = None
         self._propagation_lr: Optional[Union[float, str]] = None
+        self._propagation_optimizer: Optional[str] = None
         self._prediction_fn: Optional[Callable] = None
 
     def add_layer(
@@ -147,13 +148,20 @@ class VectorizedDeepNetwork:
         Raises
         ------
         ValueError
-            If *kind* is not ``"volatile"`` or ``"binary"``.
+            If *kind* is not a recognised node type.
         ValueError
             If *fully_connected* is False with ``add_constant_input=True``.
         ValueError
             If *fully_connected* is False and this layer's size differs from
             the preceding child layer.
         """
+        # Normalise Rust-style kind names to short form
+        _kind_aliases = {
+            "volatile-state": "volatile",
+            "binary-state": "binary",
+        }
+        kind = _kind_aliases.get(kind, kind)
+
         valid_kinds = {"volatile", "binary"}
         if kind not in valid_kinds:
             raise ValueError(
@@ -278,11 +286,18 @@ class VectorizedDeepNetwork:
                 else:
                     weights.append(jnp.eye(prev_size, n_parent_cols))
 
+        # Adam moment buffers (zeros, same shapes as weights)
+        adam_m = tuple(jnp.zeros_like(w) for w in weights)
+        adam_v = tuple(jnp.zeros_like(w) for w in weights)
+
         return NetworkState(
             layers=tuple(layers),
             weights=tuple(weights),
             params=tuple(params),
             time_step=1.0,
+            adam_m=adam_m,
+            adam_v=adam_v,
+            adam_t=0,
         )
 
     def weight_initialisation(
@@ -351,12 +366,17 @@ class VectorizedDeepNetwork:
             weights=tuple(new_weights),
             params=self.state.params,
             time_step=self.state.time_step,
+            adam_m=self.state.adam_m,
+            adam_v=self.state.adam_v,
+            adam_t=self.state.adam_t,
         )
         return self
 
     def _create_propagation_fn(
         self,
         lr: Union[float, str],
+        optimizer: Optional[str] = None,
+        params: Optional[dict] = None,
     ):
         """Create the jitted propagation function.
 
@@ -364,6 +384,12 @@ class VectorizedDeepNetwork:
         ----------
         lr :
             Learning rate for weight updates.
+        optimizer :
+            Optimizer name.  ``"adam"`` enables Adam filtering of weight
+            gradients.  *None* uses plain gradient updates.
+        params :
+            Hyper-parameters for the optimizer (e.g. ``beta1``, ``beta2``,
+            ``epsilon``, and ``lr`` for Adam).  See :meth:`fit` for defaults.
 
         Returns
         -------
@@ -378,6 +404,19 @@ class VectorizedDeepNetwork:
         add_constant_inputs = self.add_constant_inputs  # captured for bias updates
         layer_kinds = self.layer_kinds
 
+        # Build Adam parameters tuple (or None)
+        # Format: (beta1, beta2, epsilon, adam_lr_override)
+        if optimizer == "adam":
+            p = params or {}
+            adam_params: Optional[tuple[float, float, float, Optional[float]]] = (
+                p.get("beta1", 0.9),
+                p.get("beta2", 0.999),
+                p.get("epsilon", 1e-8),
+                p.get("lr", 1e-3),
+            )
+        else:
+            adam_params = None
+
         def _step(state: NetworkState, inputs):
             return propagation_step(
                 state,
@@ -387,6 +426,7 @@ class VectorizedDeepNetwork:
                 add_constant_inputs,
                 lr,
                 layer_kinds,
+                adam_params,
             )
 
         return jax.jit(_step)
@@ -444,6 +484,8 @@ class VectorizedDeepNetwork:
         x: Union[np.ndarray, jnp.ndarray],
         y: Union[np.ndarray, jnp.ndarray],
         lr: Union[float, str] = 0.2,
+        optimizer: Optional[str] = "adam",
+        params: Optional[dict] = None,
     ) -> "VectorizedDeepNetwork":
         """Fit network to data.
 
@@ -456,26 +498,52 @@ class VectorizedDeepNetwork:
         lr :
             Learning rate for weight updates, or ``"dynamic"`` for
             Kalman-gain updates.
+        optimizer :
+            Optimizer name.  ``"adam"`` (default) filters weight gradients
+            through the Adam algorithm (Kingma & Ba, 2015).  *None* uses
+            plain gradient or Kalman-gain updates.
+        params :
+            Dictionary of optimizer hyper-parameters.  For Adam:
+            ``beta1`` (default 0.9), ``beta2`` (default 0.999),
+            ``epsilon`` (default 1e-8), and ``lr`` (default 1e-3,
+            the Adam step size).
 
         Returns
         -------
         VectorizedDeepNetwork
             Self with updated state.
+
+        Raises
+        ------
+        ValueError
+            If *optimizer* is not ``None`` or ``"adam"``.
         """
+        if optimizer is not None and optimizer != "adam":
+            raise ValueError(
+                f"Unknown optimizer '{optimizer}'. Supported: 'adam' or None."
+            )
+
         # Initialize state if needed
         if self.state is None:
             self.state = self._init_state()
 
-        # Only recreate (and retrace) the propagation fn when lr changes
-        if self._propagation_fn is None or self._propagation_lr != lr:
-            self._propagation_fn = self._create_propagation_fn(lr)
+        # Recreate (and retrace) the propagation fn when settings change
+        needs_retrace = (
+            self._propagation_fn is None
+            or self._propagation_lr != lr
+            or self._propagation_optimizer != optimizer
+        )
+        if needs_retrace:
+            self._propagation_fn = self._create_propagation_fn(lr, optimizer, params)
             self._propagation_lr = lr
+            self._propagation_optimizer = optimizer
 
         # Convert to JAX arrays
         x = jnp.asarray(x)
         y = jnp.asarray(y)
 
         # Run scan over data
+        assert self._propagation_fn is not None
         self.state, (self.trajectories, self.predictions) = jax.lax.scan(
             self._propagation_fn, self.state, (x, y)
         )
@@ -525,6 +593,7 @@ class VectorizedDeepNetwork:
         self.state = self._init_state()
         self._propagation_fn = None
         self._propagation_lr = None
+        self._propagation_optimizer = None
         self._prediction_fn = None
         return self
 

--- a/pyhgf/typing.py
+++ b/pyhgf/typing.py
@@ -174,6 +174,9 @@ class NetworkState(NamedTuple):
     weights: tuple  # tuple[Array, ...] - weights[i] connects layer[i] to layer[i+1]
     params: tuple  # tuple[LayerParams, ...] - params[i] for layer[i]
     time_step: float
+    adam_m: tuple  # tuple[Array, ...] - first moment estimates (same shapes as weights)
+    adam_v: tuple  # tuple[Array, ...] - second moment estimates
+    adam_t: int  # global timestep counter
 
     @property
     def n_layers(self) -> int:

--- a/pyhgf/updates/vectorized/learning.py
+++ b/pyhgf/updates/vectorized/learning.py
@@ -17,7 +17,13 @@ def vectorized_weight_update(
     coupling_fn: Callable,
     lr: Optional[float] = None,
     parent_has_constant: bool = False,
-) -> jnp.ndarray:
+    adam_m: Optional[jnp.ndarray] = None,
+    adam_v: Optional[jnp.ndarray] = None,
+    adam_t: int = 0,
+    adam_beta1: float = 0.9,
+    adam_beta2: float = 0.999,
+    adam_epsilon: float = 1e-8,
+) -> tuple[jnp.ndarray, Optional[jnp.ndarray], Optional[jnp.ndarray]]:
     r"""Unified weight update for vectorized layers.
 
     Branches on the ``lr`` parameter:
@@ -28,6 +34,9 @@ def vectorized_weight_update(
     - **Dynamic** (``lr is None``): Kalman-gain rule.
       :math:`K = \pi_\text{parent} / (\pi_\text{parent} + \pi_\text{child})`
       :math:`\Delta w = K \cdot \text{PE} \cdot g(\text{parent})`
+
+    When ``adam_m`` and ``adam_v`` are provided (not *None*), the fixed-LR gradient is
+    filtered through Adam before being applied.
 
     Parameters
     ----------
@@ -48,11 +57,28 @@ def vectorized_weight_update(
         If True, the parent layer has a constant input node.  The parent
         mean is augmented with 1.0 and the precision with the parent
         precision mean so the bias column of *weights* is updated.
+    adam_m :
+        First moment estimate for Adam, same shape as *weights*.
+        Pass ``None`` to disable Adam.
+    adam_v :
+        Second moment estimate for Adam, same shape as *weights*.
+    adam_t :
+        Global Adam timestep (already incremented for this step).
+    adam_beta1 :
+        Exponential decay rate for the first moment.
+    adam_beta2 :
+        Exponential decay rate for the second moment.
+    adam_epsilon :
+        Small constant for numerical stability.
 
     Returns
     -------
-    jnp.ndarray
+    new_weights :
         Updated weight matrix.
+    new_adam_m :
+        Updated first moment (or *None* when Adam is not used).
+    new_adam_v :
+        Updated second moment (or *None* when Adam is not used).
     """
     # Prediction error at child layer
     pe = child_state.mean - child_state.expected_mean
@@ -61,8 +87,6 @@ def vectorized_weight_update(
     parent_mean = parent_state.mean
     parent_precision = parent_state.precision
     if parent_has_constant:
-        # Append constant 1.0 for bias node; use parent mean precision
-        # for the bias entry so the Kalman gain remains well-defined.
         parent_mean = jnp.concatenate([parent_mean, jnp.ones(1)])
         parent_precision = jnp.concatenate([
             parent_precision,
@@ -71,18 +95,31 @@ def vectorized_weight_update(
     coupled_parent = coupling_fn(parent_mean)
 
     # Base outer product: PE ⊗ g(parent)
-    # Broadcast: (n_children, 1) * (1, n_parents) -> (n_children, n_parents)
     coupling_delta = pe[:, None] * coupled_parent[None, :]
 
     if lr is not None:
-        # Fixed LR: scale by lr · π_child
-        coupling_delta = coupling_delta * child_state.precision[:, None] * lr
+        # Raw gradient (before LR scaling)
+        gradient = coupling_delta * child_state.precision[:, None]
+
+        if adam_m is not None and adam_v is not None:
+            # Adam-filtered update
+            new_m = adam_beta1 * adam_m + (1.0 - adam_beta1) * gradient
+            new_v = adam_beta2 * adam_v + (1.0 - adam_beta2) * gradient**2
+            m_hat = new_m / (1.0 - adam_beta1**adam_t)
+            v_hat = new_v / (1.0 - adam_beta2**adam_t)
+            coupling_delta = lr * m_hat / (jnp.sqrt(v_hat) + adam_epsilon)
+        else:
+            coupling_delta = gradient * lr
+            new_m = None
+            new_v = None
     else:
-        # Dynamic: scale by Kalman gain K = π_parent / (π_parent + π_child)
+        # Dynamic: Kalman gain (Adam not applicable)
         kalman_gain = parent_precision[None, :] / (
             parent_precision[None, :] + child_state.precision[:, None]
         )
         coupling_delta = coupling_delta * kalman_gain
+        new_m = None
+        new_v = None
 
     # Guard against NaN / inf
     coupling_delta = jnp.where(
@@ -92,4 +129,4 @@ def vectorized_weight_update(
     new_weights = weights + coupling_delta
     new_weights = jnp.where(jnp.isinf(new_weights), weights, new_weights)
 
-    return new_weights
+    return new_weights, new_m, new_v

--- a/pyhgf/utils/vectorized_belief_propagation.py
+++ b/pyhgf/utils/vectorized_belief_propagation.py
@@ -30,6 +30,7 @@ def propagation_step(
     add_constant_inputs: list[bool],
     lr: Union[float, str],
     layer_kinds: Optional[list[str]] = None,
+    adam_params: Optional[tuple[float, float, float, Optional[float]]] = None,
 ) -> tuple[NetworkState, tuple[NetworkState, jnp.ndarray]]:
     """Single propagation step through the network.
 
@@ -54,6 +55,10 @@ def propagation_step(
     layer_kinds :
         Per-layer node type (``"volatile"`` or ``"binary"``).  Defaults to
         all ``"volatile"`` when *None*.
+    adam_params :
+        Tuple ``(beta1, beta2, epsilon, lr_override)`` for Adam optimiser.
+        ``lr_override`` is an optional Adam-specific learning rate that overrides the
+        main *lr* argument.  When *None*, Adam is not used.
 
     Returns
     -------
@@ -137,21 +142,46 @@ def propagation_step(
     # ========== LEARNING PHASE (after inference converges) ==========
     # Update weights once using converged activities
     lr_value: Optional[float] = None if lr == "dynamic" else float(lr)
+
+    adam_m_list = list(state.adam_m)
+    adam_v_list = list(state.adam_v)
+    use_adam = adam_params is not None
+    adam_t = state.adam_t + 1 if use_adam else state.adam_t
+    if adam_params is not None:
+        beta1, beta2, epsilon, adam_lr_override = adam_params
+        # Adam lr override takes precedence (matches Rust behaviour)
+        if adam_lr_override is not None:
+            lr_value = adam_lr_override
+    else:
+        beta1, beta2, epsilon = 0.9, 0.999, 1e-8
+
     for i in range(1, n_layers):
-        weights[i - 1] = vectorized_weight_update(
+        weights[i - 1], new_m, new_v = vectorized_weight_update(
             parent_state=layers[i],
             child_state=layers[i - 1],
             weights=weights[i - 1],
             coupling_fn=coupling_fns[i],
             lr=lr_value,
             parent_has_constant=add_constant_inputs[i],
+            adam_m=adam_m_list[i - 1] if use_adam else None,
+            adam_v=adam_v_list[i - 1] if use_adam else None,
+            adam_t=adam_t,
+            adam_beta1=beta1,
+            adam_beta2=beta2,
+            adam_epsilon=epsilon,
         )
+        if use_adam and new_m is not None:
+            adam_m_list[i - 1] = new_m
+            adam_v_list[i - 1] = new_v
 
     new_state = NetworkState(
         layers=tuple(layers),
         weights=tuple(weights),
         params=tuple(params),
         time_step=state.time_step,
+        adam_m=tuple(adam_m_list),
+        adam_v=tuple(adam_v_list),
+        adam_t=adam_t,
     )
 
     # Return output prediction for monitoring

--- a/src/model.rs
+++ b/src/model.rs
@@ -907,9 +907,9 @@ impl Network {
             let beta1 = params.and_then(|p| p.get("beta1").copied()).unwrap_or(0.9);
             let beta2 = params.and_then(|p| p.get("beta2").copied()).unwrap_or(0.999);
             let epsilon = params.and_then(|p| p.get("epsilon").copied()).unwrap_or(1e-8);
-            let adam_lr = params.and_then(|p| p.get("lr").copied());
+            let adam_lr = params.and_then(|p| p.get("lr").copied()).unwrap_or(1e-3);
             let mut adam = AdamState::new(&coupling_sizes, beta1, beta2, epsilon);
-            adam.lr = adam_lr;
+            adam.lr = Some(adam_lr);
             self.adam_state = Some(adam);
         } else {
             self.adam_state = None;
@@ -1350,7 +1350,7 @@ impl Network {
         Ok(slf)
     }
 
-    #[pyo3(name = "fit", signature = (x, y, inputs_x_idxs=None, inputs_y_idxs=None, lr=None, record_trajectories=true, optimizer=None, params=None))]
+    #[pyo3(name = "fit", signature = (x, y, inputs_x_idxs=None, inputs_y_idxs=None, lr=None, record_trajectories=true, optimizer="adam", params=None))]
     fn py_fit<'py>(
         mut slf: PyRefMut<'py, Self>,
         x: Bound<'py, PyAny>,
@@ -1359,7 +1359,7 @@ impl Network {
         inputs_y_idxs: Option<Vec<usize>>,
         lr: Option<Bound<'py, PyAny>>,
         record_trajectories: bool,
-        optimizer: Option<String>,
+        optimizer: Option<&str>,
         params: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<PyRefMut<'py, Self>> {
         let lr_option: Option<f64> = match lr {
@@ -1416,7 +1416,7 @@ impl Network {
             None => None,
         };
 
-        slf.fit(&x_data, &y_data, &x_idxs, &y_idxs, lr_option, record_trajectories, optimizer.as_deref(), params_map.as_ref());
+        slf.fit(&x_data, &y_data, &x_idxs, &y_idxs, lr_option, record_trajectories, optimizer, params_map.as_ref());
         Ok(slf)
     }
 

--- a/tests/test_deepnetwork.py
+++ b/tests/test_deepnetwork.py
@@ -129,13 +129,17 @@ def test_fit():
                     )
 
                 predictors = tuple(net.layers[-1][:n_input])
-                net.fit(
+                fit_kwargs = dict(
                     x=x,
                     y=y,
                     inputs_x_idxs=predictors,
                     inputs_y_idxs=tuple(range(n_targets)),
                     lr=lr,
                 )
+                # Rust defaults to Adam; override to plain updates for parity
+                if Network is RsNetwork:
+                    fit_kwargs["optimizer"] = None
+                net.fit(**fit_kwargs)
                 fitted.append(net)
 
             py_net, rs_net = fitted

--- a/tests/test_vectorized_deep_network.py
+++ b/tests/test_vectorized_deep_network.py
@@ -339,7 +339,9 @@ class TestVectorizedUpdates:
             parent_state, child_state, weights, jnp.tanh, lr=0.1
         )
 
-        assert result.shape == (10, 8)
+        assert result[0].shape == (10, 8)
+        assert result[1] is None  # no Adam
+        assert result[2] is None
 
 
 class TestAddLayerValidation:


### PR DESCRIPTION
This pull request introduces Adam optimizer support to the vectorized deep network implementation in Python, aligning its behavior with the Rust backend and making optimizer usage more flexible and explicit. The main changes include adding Adam moment buffers to the network state, updating the weight update logic to support Adam, and allowing users to select and configure the optimizer via the `fit` method. Tests and documentation are updated accordingly.

**Adam optimizer integration and state management:**

* Added Adam moment buffers (`adam_m`, `adam_v`) and a timestep counter (`adam_t`) to the `NetworkState` to support Adam optimizer state tracking. [[1]](diffhunk://#diff-ce701a0232354d98ff066357e1786a41187b7ac3b243e6dd32a0985c0389cb8dR289-R300) [[2]](diffhunk://#diff-4ecb7dc2a4f75851950353f7bf07f6cc2c17470b38ac299dceb9d6ca1a9f0cbaR177-R179)
* Modified the weight update function `vectorized_weight_update` to optionally apply Adam filtering to gradients, updating and returning the moment buffers as needed. [[1]](diffhunk://#diff-3771b528c1e12452235259e9a06bfcfce79669d717ccef260cf6092839313b87L20-R26) [[2]](diffhunk://#diff-3771b528c1e12452235259e9a06bfcfce79669d717ccef260cf6092839313b87R38-R40) [[3]](diffhunk://#diff-3771b528c1e12452235259e9a06bfcfce79669d717ccef260cf6092839313b87R60-R81) [[4]](diffhunk://#diff-3771b528c1e12452235259e9a06bfcfce79669d717ccef260cf6092839313b87L74-R122) [[5]](diffhunk://#diff-3771b528c1e12452235259e9a06bfcfce79669d717ccef260cf6092839313b87L95-R132)
* Updated the propagation step (`propagation_step`) to handle Adam parameters, manage moment buffers, and increment the timestep when Adam is used. [[1]](diffhunk://#diff-06a2ab3e9dd3e02e4721916fd77e9d2f705ca551f370825a98fbbd11d1affe16R33) [[2]](diffhunk://#diff-06a2ab3e9dd3e02e4721916fd77e9d2f705ca551f370825a98fbbd11d1affe16R58-R61) [[3]](diffhunk://#diff-06a2ab3e9dd3e02e4721916fd77e9d2f705ca551f370825a98fbbd11d1affe16R145-R184)

**API and configuration improvements:**

* The `fit` method of `VectorizedDeepNetwork` now accepts an `optimizer` argument (default `"adam"`) and a `params` dictionary for optimizer hyperparameters, with validation for supported optimizers. The propagation function is retraced when optimizer settings change. [[1]](diffhunk://#diff-ce701a0232354d98ff066357e1786a41187b7ac3b243e6dd32a0985c0389cb8dR487-R488) [[2]](diffhunk://#diff-ce701a0232354d98ff066357e1786a41187b7ac3b243e6dd32a0985c0389cb8dR501-R546)
* The Rust backend's Python bindings are updated to default to `"adam"` optimizer and accept optimizer configuration consistently. [[1]](diffhunk://#diff-6bd13171e8498a8adc17d13cef1f1b59f5fbd24ae4c72aeb4ce5f9b2b4703220L1353-R1353) [[2]](diffhunk://#diff-6bd13171e8498a8adc17d13cef1f1b59f5fbd24ae4c72aeb4ce5f9b2b4703220L1362-R1362) [[3]](diffhunk://#diff-6bd13171e8498a8adc17d13cef1f1b59f5fbd24ae4c72aeb4ce5f9b2b4703220L1419-R1419)
* Adam's learning rate default and handling in Rust are aligned with Python's behavior.

**Validation, normalization, and tests:**

* Added normalization for Rust-style layer kind names in `add_layer`, and improved error messages for unrecognized kinds and optimizers. [[1]](diffhunk://#diff-ce701a0232354d98ff066357e1786a41187b7ac3b243e6dd32a0985c0389cb8dL150-R164) [[2]](diffhunk://#diff-ce701a0232354d98ff066357e1786a41187b7ac3b243e6dd32a0985c0389cb8dR487-R488)
* Updated tests to explicitly control optimizer selection for backend parity, and to check the structure of weight update results with and without Adam. [[1]](diffhunk://#diff-342b77c0fb3d5e6678450497973ff573a5db0410a9ab7d43cd186a53984b0e83L132-R142) [[2]](diffhunk://#diff-11dcea40e41cdf026b13081697b0960b531c67444b3d1652387f551635b80771L342-R344)