### PR TITLE
add a record_trajectories parameter to the JAX backend

### DIFF
--- a/pyhgf/model/network.py
+++ b/pyhgf/model/network.py
@@ -406,6 +406,7 @@ class Network:
         observed: Optional[tuple[ArrayLike, ...]] = None,
         input_idxs: Optional[tuple[int]] = None,
         rng_keys: Optional[random.PRNGKey] = None,
+        record_trajectories: bool = True,
     ):
         """Add new observations.
 
@@ -435,6 +436,11 @@ class Network:
         rng_keys :
             Optional. A random key for the random number generator. This is only used
             when an action function is provided.
+        record_trajectories :
+            If True (default), record the full node trajectories at every time
+            step (accessible via ``self.node_trajectories``).  If False, only
+            the final state is kept, which significantly reduces memory usage
+            and speeds up training.
 
         """
         if rng_keys is not None:
@@ -478,10 +484,20 @@ class Network:
         # this is where the model loops over the whole input time series
         # at each time point, the node structure is traversed and beliefs are updated
         # using precision-weighted prediction errors
-        last_attributes, node_trajectories = scan(self.scan_fn, self.attributes, inputs)
+        if record_trajectories:
+            last_attributes, node_trajectories = scan(
+                self.scan_fn, self.attributes, inputs
+            )
+            self.node_trajectories = node_trajectories
+        else:
 
-        # belief trajectories
-        self.node_trajectories = node_trajectories
+            def _no_traj_step(attributes, inputs):
+                new_attributes, _ = self.scan_fn(attributes, inputs)
+                return new_attributes, None
+
+            last_attributes, _ = scan(_no_traj_step, self.attributes, inputs)
+            self.node_trajectories = None  # type: ignore[assignment]
+
         self.last_attributes = last_attributes
 
         return self

--- a/pyhgf/model/vectorized_deep_network.py
+++ b/pyhgf/model/vectorized_deep_network.py
@@ -94,6 +94,7 @@ class VectorizedDeepNetwork:
         self._propagation_fn: Optional[Callable] = None
         self._propagation_lr: Optional[Union[float, str]] = None
         self._propagation_optimizer: Optional[str] = None
+        self._record_trajectories: bool = False
         self._prediction_fn: Optional[Callable] = None
 
     def add_layer(
@@ -377,6 +378,7 @@ class VectorizedDeepNetwork:
         lr: Union[float, str],
         optimizer: Optional[str] = None,
         params: Optional[dict] = None,
+        record_trajectories: bool = False,
     ):
         """Create the jitted propagation function.
 
@@ -390,6 +392,10 @@ class VectorizedDeepNetwork:
         params :
             Hyper-parameters for the optimizer (e.g. ``beta1``, ``beta2``,
             ``epsilon``, and ``lr`` for Adam).  See :meth:`fit` for defaults.
+        record_trajectories :
+            If True, the scan output includes the full ``NetworkState`` at
+            every time step (useful for inspection but significantly slower).
+            If False (default), only predictions are accumulated.
 
         Returns
         -------
@@ -417,17 +423,34 @@ class VectorizedDeepNetwork:
         else:
             adam_params = None
 
-        def _step(state: NetworkState, inputs):
-            return propagation_step(
-                state,
-                inputs,
-                coupling_fns,
-                coupling_fn_grads,
-                add_constant_inputs,
-                lr,
-                layer_kinds,
-                adam_params,
-            )
+        if record_trajectories:
+
+            def _step(state: NetworkState, inputs):
+                new_state, output_pred = propagation_step(
+                    state,
+                    inputs,
+                    coupling_fns,
+                    coupling_fn_grads,
+                    add_constant_inputs,
+                    lr,
+                    layer_kinds,
+                    adam_params,
+                )
+                return new_state, (new_state, output_pred)
+
+        else:
+
+            def _step(state: NetworkState, inputs):
+                return propagation_step(
+                    state,
+                    inputs,
+                    coupling_fns,
+                    coupling_fn_grads,
+                    add_constant_inputs,
+                    lr,
+                    layer_kinds,
+                    adam_params,
+                )
 
         return jax.jit(_step)
 
@@ -486,6 +509,7 @@ class VectorizedDeepNetwork:
         lr: Union[float, str] = 0.2,
         optimizer: Optional[str] = "adam",
         params: Optional[dict] = None,
+        record_trajectories: bool = False,
     ) -> "VectorizedDeepNetwork":
         """Fit network to data.
 
@@ -499,14 +523,17 @@ class VectorizedDeepNetwork:
             Learning rate for weight updates, or ``"dynamic"`` for
             Kalman-gain updates.
         optimizer :
-            Optimizer name.  ``"adam"`` (default) filters weight gradients
-            through the Adam algorithm (Kingma & Ba, 2015).  *None* uses
-            plain gradient or Kalman-gain updates.
+            Optimizer name.  ``"adam"`` (default) filters weight gradients through the
+            Adam algorithm (Kingma & Ba, 2015).  *None* uses plain gradient or
+            Kalman-gain updates.
         params :
-            Dictionary of optimizer hyper-parameters.  For Adam:
-            ``beta1`` (default 0.9), ``beta2`` (default 0.999),
-            ``epsilon`` (default 1e-8), and ``lr`` (default 1e-3,
-            the Adam step size).
+            Dictionary of optimizer hyper-parameters.  For Adam: ``beta1`` (default
+            0.9), ``beta2`` (default 0.999), ``epsilon`` (default 1e-8), and ``lr``
+            (default 1e-3, the Adam step size).
+        record_trajectories :
+            If True, record the full ``NetworkState`` at every time step (accessible
+            via ``self.trajectories``).  This is useful for inspection but significantly
+            increases memory usage and slows training. Default is False.
 
         Returns
         -------
@@ -532,11 +559,15 @@ class VectorizedDeepNetwork:
             self._propagation_fn is None
             or self._propagation_lr != lr
             or self._propagation_optimizer != optimizer
+            or self._record_trajectories != record_trajectories
         )
         if needs_retrace:
-            self._propagation_fn = self._create_propagation_fn(lr, optimizer, params)
+            self._propagation_fn = self._create_propagation_fn(
+                lr, optimizer, params, record_trajectories
+            )
             self._propagation_lr = lr
             self._propagation_optimizer = optimizer
+            self._record_trajectories = record_trajectories
 
         # Convert to JAX arrays
         x = jnp.asarray(x)
@@ -544,9 +575,15 @@ class VectorizedDeepNetwork:
 
         # Run scan over data
         assert self._propagation_fn is not None
-        self.state, (self.trajectories, self.predictions) = jax.lax.scan(
-            self._propagation_fn, self.state, (x, y)
-        )
+        if record_trajectories:
+            self.state, (self.trajectories, self.predictions) = jax.lax.scan(
+                self._propagation_fn, self.state, (x, y)
+            )
+        else:
+            self.trajectories = None
+            self.state, self.predictions = jax.lax.scan(
+                self._propagation_fn, self.state, (x, y)
+            )
 
         return self
 
@@ -594,6 +631,7 @@ class VectorizedDeepNetwork:
         self._propagation_fn = None
         self._propagation_lr = None
         self._propagation_optimizer = None
+        self._record_trajectories = False
         self._prediction_fn = None
         return self
 

--- a/pyhgf/utils/vectorized_belief_propagation.py
+++ b/pyhgf/utils/vectorized_belief_propagation.py
@@ -31,7 +31,7 @@ def propagation_step(
     lr: Union[float, str],
     layer_kinds: Optional[list[str]] = None,
     adam_params: Optional[tuple[float, float, float, Optional[float]]] = None,
-) -> tuple[NetworkState, tuple[NetworkState, jnp.ndarray]]:
+) -> tuple[NetworkState, jnp.ndarray]:
     """Single propagation step through the network.
 
     This performs a full inference-then-learning cycle for one data sample:
@@ -64,8 +64,8 @@ def propagation_step(
     -------
     new_state :
         Updated network state.
-    (new_state, output_pred) :
-        Carry-along tuple for ``jax.lax.scan`` compatibility.
+    output_pred :
+        Output layer prediction (expected mean).
     """
     x, y = inputs
     layers = list(state.layers)
@@ -187,4 +187,4 @@ def propagation_step(
     # Return output prediction for monitoring
     output_pred = layers[0].expected_mean
 
-    return new_state, (new_state, output_pred)
+    return new_state, output_pred

--- a/tests/test_continuous.py
+++ b/tests/test_continuous.py
@@ -127,3 +127,37 @@ def test_continuous_scan_loop():
         [0.25191233, 0.25114372, -3.5367591, -3.5352085],
     ):
         assert jnp.isclose(two_level_hgf.node_trajectories[2][idx][-1], val)
+
+
+def test_record_trajectories():
+    """Test input_data with record_trajectories=True and False."""
+    timeserie = load_data("continuous")
+
+    # record_trajectories=True (default) should store full trajectories
+    net_with = (
+        Network()
+        .add_nodes()
+        .add_nodes(value_children=0)
+        .input_data(input_data=timeserie, record_trajectories=True)
+    )
+    assert net_with.node_trajectories is not None
+    assert len(net_with.node_trajectories[0]["mean"]) == len(timeserie)
+    assert net_with.last_attributes is not None
+
+    # record_trajectories=False should skip trajectories but keep last state
+    net_without = (
+        Network()
+        .add_nodes()
+        .add_nodes(value_children=0)
+        .input_data(input_data=timeserie, record_trajectories=False)
+    )
+    assert net_without.node_trajectories is None
+    assert net_without.last_attributes is not None
+
+    # final state should be the same regardless of recording
+    for node_idx in [0, 1]:
+        for key in ["mean", "precision"]:
+            assert jnp.isclose(
+                net_with.last_attributes[node_idx][key],
+                net_without.last_attributes[node_idx][key],
+            )

--- a/tests/test_vectorized_deep_network.py
+++ b/tests/test_vectorized_deep_network.py
@@ -153,6 +153,37 @@ class TestVectorizedDeepNetwork:
         # Check predictions shape
         assert net.predictions.shape == (n_samples, 3)
 
+    def test_fit_record_trajectories(self):
+        """Test fit with record_trajectories=True and False."""
+        net = (
+            VectorizedDeepNetwork()
+            .add_layer(size=3)
+            .add_layer(size=5)
+            .add_layer(size=4)
+        )
+
+        n_samples = 10
+        x = np.random.randn(n_samples, 4)
+        y = np.random.randn(n_samples, 3)
+
+        # record_trajectories=False (default)
+        net.fit(x, y, lr=0.1, record_trajectories=False)
+        assert net.trajectories is None
+        assert net.predictions is not None
+        assert net.predictions.shape == (n_samples, 3)
+        state_no_traj = net.state
+
+        # reset and fit with record_trajectories=True
+        net.reset()
+        net.fit(x, y, lr=0.1, record_trajectories=True)
+        assert net.trajectories is not None
+        assert net.predictions is not None
+        assert net.predictions.shape == (n_samples, 3)
+
+        # final states should match
+        for w_a, w_b in zip(state_no_traj.weights, net.state.weights):
+            assert np.allclose(w_a, w_b, atol=1e-5)
+
     def test_predict(self):
         """Test prediction after fitting."""
         net = (

--- a/tests/test_vectorized_deep_network.py
+++ b/tests/test_vectorized_deep_network.py
@@ -147,7 +147,7 @@ class TestVectorizedDeepNetwork:
         net.fit(x, y, lr=0.1)
 
         assert net.state is not None
-        assert net.trajectories is not None
+        assert net.trajectories is None  # not recorded by default
         assert net.predictions is not None
 
         # Check predictions shape


### PR DESCRIPTION
This pull request introduces an optional mechanism for recording full node and network trajectories during model training and inference, allowing users to trade off between memory/speed and inspection/debugging capabilities. By default, trajectory recording is disabled to optimize performance and memory usage, but it can be enabled via a new `record_trajectories` parameter in the relevant methods. The implementation includes changes to both the classic and vectorized deep network models, as well as updates to the propagation step and associated tests.

**Trajectory Recording Feature**

* Added a `record_trajectories` parameter (default `False`) to `VectorizedDeepNetwork.fit`, `_create_propagation_fn`, and the class itself, controlling whether the full `NetworkState` is recorded at each step (`self.trajectories`) or only predictions are kept. Documentation and logic were updated accordingly. [[1]](diffhunk://#diff-ce701a0232354d98ff066357e1786a41187b7ac3b243e6dd32a0985c0389cb8dR97) [[2]](diffhunk://#diff-ce701a0232354d98ff066357e1786a41187b7ac3b243e6dd32a0985c0389cb8dR381) [[3]](diffhunk://#diff-ce701a0232354d98ff066357e1786a41187b7ac3b243e6dd32a0985c0389cb8dR395-R398) [[4]](diffhunk://#diff-ce701a0232354d98ff066357e1786a41187b7ac3b243e6dd32a0985c0389cb8dR512) [[5]](diffhunk://#diff-ce701a0232354d98ff066357e1786a41187b7ac3b243e6dd32a0985c0389cb8dL502-R536) [[6]](diffhunk://#diff-ce701a0232354d98ff066357e1786a41187b7ac3b243e6dd32a0985c0389cb8dR562-R586) [[7]](diffhunk://#diff-ce701a0232354d98ff066357e1786a41187b7ac3b243e6dd32a0985c0389cb8dR634)
* In the classic `Network.input_data` method, added a `record_trajectories` parameter (default `True`) to control whether the full node trajectories are recorded (`self.node_trajectories`) or only the final state is kept, reducing memory usage and speeding up training if disabled. [[1]](diffhunk://#diff-2cdbec5bbaa5ef09f3f530d526ef809eac5d815b3e71fa701c220ca96da15f18R409) [[2]](diffhunk://#diff-2cdbec5bbaa5ef09f3f530d526ef809eac5d815b3e71fa701c220ca96da15f18R439-R443) [[3]](diffhunk://#diff-2cdbec5bbaa5ef09f3f530d526ef809eac5d815b3e71fa701c220ca96da15f18L481-R500)

**Propagation Step and Scan Logic**

* Modified `propagation_step` in `vectorized_belief_propagation.py` to return only the output prediction (not the state tuple) for compatibility with the new scan logic and to avoid unnecessary memory usage when trajectory recording is off. [[1]](diffhunk://#diff-06a2ab3e9dd3e02e4721916fd77e9d2f705ca551f370825a98fbbd11d1affe16L34-R34) [[2]](diffhunk://#diff-06a2ab3e9dd3e02e4721916fd77e9d2f705ca551f370825a98fbbd11d1affe16L67-R68) [[3]](diffhunk://#diff-06a2ab3e9dd3e02e4721916fd77e9d2f705ca551f370825a98fbbd11d1affe16L190-R190)
* Updated scan logic in both classic and vectorized models to conditionally accumulate trajectories or not, based on the new parameter. [[1]](diffhunk://#diff-2cdbec5bbaa5ef09f3f530d526ef809eac5d815b3e71fa701c220ca96da15f18L481-R500) [[2]](diffhunk://#diff-ce701a0232354d98ff066357e1786a41187b7ac3b243e6dd32a0985c0389cb8dR426-R442) [[3]](diffhunk://#diff-ce701a0232354d98ff066357e1786a41187b7ac3b243e6dd32a0985c0389cb8dR562-R586)

**Testing and Defaults**

* Updated tests to assert that, by default, trajectories are not recorded (i.e., `net.trajectories` is `None`).
* Ensured that the `reset` method clears the trajectory recording flag in `VectorizedDeepNetwork`.