### PR TITLE
fix documentation

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -191,3 +191,13 @@ This implementation of the Hierarchical Gaussian Filter was inspired by the orig
 7. Mathys, C., Weber, L. (2020). Hierarchical Gaussian Filtering of Sufficient Statistic Time Series for Active Inference. In: Verbelen, T., Lanillos, P., Buckley, C.L., De Boom, C. (eds) Active Inference. IWAI 2020. Communications in Computer and Information Science, vol 1326. Springer, Cham. https://doi.org/10.1007/978-3-030-64919-7_7
 8. Friston, K., Da Costa, L., Hafner, D., Hesp, C., & Parr, T. (2021). Sophisticated Inference. Neural Computation, 33(3), 713–763. https://doi.org/10.1162/neco_a_01351 
 9. Song, Y., Millidge, B., Salvatori, T. et al. Inferring neural activity before plasticity as a foundation for learning beyond backpropagation. Nat Neurosci 27, 348–358 (2024). https://doi.org/10.1038/s41593-023-01514-1 
+
+```{toctree}
+---
+hidden:
+---
+Learn <learn.md>
+API <api.rst>
+Cite <cite.md>
+References <references.md>
+```

--- a/docs/source/notebooks/0.5-Learning.ipynb
+++ b/docs/source/notebooks/0.5-Learning.ipynb
@@ -1487,7 +1487,7 @@
    "source": [
     "### Decision boundary evolution\n",
     "\n",
-    "We animate the decision boundary heatmap across training epochs alongside the loss curve. The GIF shows how the predictive coding network gradually carves out a non-linear separator to distinguish the two moons."
+    "We animate the decision boundary heatmap across training epochs alongside the loss curve."
    ]
   },
   {
@@ -1505,7 +1505,7 @@
     "---\n",
     "name: two-moons-animation\n",
     "---\n",
-    "The animation above displays the mean and covariance tracking of a bivariate normal distribution. The ellipse represents the 95% confidence interval of the covariance matrix. We can see that uncertainty is increasing in noisier sections of the distribution trajectory.\n",
+    "The GIF shows how the predictive coding network gradually carves out a non-linear separator to distinguish the two moons.\n",
     "```"
    ]
   },


### PR DESCRIPTION
This pull request updates the documentation to improve navigation and clarify explanations in the learning notebook. The most important changes are:

**Documentation Navigation Improvements:**

* Added a `toctree` to `index.md` to provide links to the Learn, API, Cite, and References pages, making it easier for users to navigate the documentation.

**Notebook Content Clarifications:**

* Updated the explanation in the learning notebook to clarify the description of the decision boundary animation, focusing on how the predictive coding network distinguishes the two moons. [[1]](diffhunk://#diff-8e3a1915fccb7209b5fa10f49d2f9fb39c18dccab3bced2ee057347526fe593fL1490-R1490) [[2]](diffhunk://#diff-8e3a1915fccb7209b5fa10f49d2f9fb39c18dccab3bced2ee057347526fe593fL1508-R1508)