### PR TITLE
fix unbounded updates for continuous and volatile nodes in Rust, JAX and vectorised JAX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rshgf"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "numpy",
  "pyo3",

--- a/pyhgf/updates/posterior/continuous/continuous_node_posterior_update_unbounded.py
+++ b/pyhgf/updates/posterior/continuous/continuous_node_posterior_update_unbounded.py
@@ -123,80 +123,68 @@ def posterior_update_unbounded(
     # ----------------------------------------------------------------------------------
     # Second quadratic approximation L2 ------------------------------------------------
     # ----------------------------------------------------------------------------------
-    phi = jnp.log(previous_child_variance * (2 + jnp.sqrt(3)))
 
-    w_phi = jnp.exp(
-        attributes[node_idx]["volatility_coupling_children"][0] * phi
-        + attributes[volatility_child_idx]["tonic_volatility"]
-    ) / (
-        previous_child_variance
-        + jnp.exp(
-            attributes[node_idx]["volatility_coupling_children"][0] * phi
-            + attributes[volatility_child_idx]["tonic_volatility"]
-        )
-    )
+    # Canonical expansion point and its map back to native space
+    ka = attributes[node_idx]["volatility_coupling_children"][0]
+    om = attributes[volatility_child_idx]["tonic_volatility"]
+    phi_canon = jnp.log(previous_child_variance * (2 + jnp.sqrt(3.0)))
+    phi_full = (phi_canon - om) / ka
+
+    # At phi_full, exp(ka*phi_full + om) = previous_child_variance*(2+sqrt(3))
+    # by construction — use this directly to avoid numerical round-trips
+    exp_at_phi = previous_child_variance * (2 + jnp.sqrt(3.0))
+
+    w_phi = exp_at_phi / (previous_child_variance + exp_at_phi)
 
     delta_phi = (
         (1 / attributes[volatility_child_idx]["precision"])
         + (
             attributes[volatility_child_idx]["mean"]
-            - (attributes[volatility_child_idx]["expected_mean"])
+            - attributes[volatility_child_idx]["expected_mean"]
         )
         ** 2
-    ) / (
-        previous_child_variance
-        + jnp.exp(
-            attributes[node_idx]["volatility_coupling_children"][0] * phi
-            + attributes[volatility_child_idx]["tonic_volatility"]
-        )
-    ) - 1.0
+    ) / (previous_child_variance + exp_at_phi) - 1.0
 
-    pi_l2 = attributes[node_idx]["expected_precision"] + 0.5 * attributes[node_idx][
-        "volatility_coupling_children"
-    ][0] ** 2 * w_phi * (w_phi + (2 * w_phi - 1) * delta_phi)
-
-    mu_hat_phi = ((2.0 * pi_l2 - 1.0) * phi + attributes[node_idx]["expected_mean"]) / (
-        2.0 * pi_l2
+    pi_l2 = attributes[node_idx]["expected_precision"] + 0.5 * ka**2 * w_phi * (
+        w_phi + (2 * w_phi - 1) * delta_phi
     )
 
-    mu_l2 = (
-        mu_hat_phi
-        + (
-            (attributes[node_idx]["volatility_coupling_children"][0] * w_phi)
-            / (2 * pi_l2)
-        )
-        * delta_phi
-    )
+    mu_hat_phi = (
+        (pi_l2 - attributes[node_idx]["expected_precision"]) * phi_full
+        + attributes[node_idx]["expected_precision"]
+        * attributes[node_idx]["expected_mean"]
+    ) / pi_l2
+
+    mu_l2 = mu_hat_phi + ((ka * w_phi) / (2 * pi_l2)) * delta_phi
 
     # ----------------------------------------------------------------------------------
     # compute the full quadratic approximation -----------------------------------------
     # ----------------------------------------------------------------------------------
-    theta_l = jnp.sqrt(
-        1.2
-        * (
-            (
-                (1 / attributes[volatility_child_idx]["precision"])
-                + (
-                    attributes[volatility_child_idx]["mean"]
-                    - attributes[volatility_child_idx]["expected_mean"]
-                )
-                ** 2
-            )
-            / (previous_child_variance * pi_l1)
-        )
-    )
 
-    # compute the weigthing of the two approximations
+    # Total posterior uncertainty at child level (be_aux in the Matlab code)
+    be_aux = (1 / attributes[volatility_child_idx]["precision"]) + (
+        attributes[volatility_child_idx]["mean"]
+        - attributes[volatility_child_idx]["expected_mean"]
+    ) ** 2
+
+    # Blending operates in canonical exponent space y = ka * muhat + om
+    y_pred = (
+        ka * attributes[node_idx]["expected_mean"]
+        + attributes[volatility_child_idx]["tonic_volatility"]
+    )
+    theta_l = -jnp.sqrt(1.2 * 2.0 * be_aux / previous_child_variance)
+
+    # Compute the weighting of the two approximations
     # using the smoothed rectangular function b
-    weigthing = smoothed_rectangular(
-        x=attributes[node_idx]["expected_mean"],
+    weighting = smoothed_rectangular(
+        x=y_pred,
         theta_l=theta_l,
         phi_l=8.0,
         theta_r=0.0,
         phi_r=1.0,
     )
 
-    posterior_precision = (1 - weigthing) * pi_l1 + weigthing * pi_l2
-    posterior_mean = (1 - weigthing) * mu_l1 + weigthing * mu_l2
+    posterior_precision = (1 - weighting) * pi_l1 + weighting * pi_l2
+    posterior_mean = (1 - weighting) * mu_l1 + weighting * mu_l2
 
     return posterior_precision, posterior_mean

--- a/pyhgf/updates/posterior/volatile/volatile_node_posterior_update_unbounded.py
+++ b/pyhgf/updates/posterior/volatile/volatile_node_posterior_update_unbounded.py
@@ -74,52 +74,53 @@ def volatile_node_posterior_update_unbounded(
     # ----------------------------------------------------------------------------------
     # Second quadratic approximation L2
     # ----------------------------------------------------------------------------------
-    phi = jnp.log(previous_child_variance * (2 + jnp.sqrt(3)))
 
-    w_phi = jnp.exp(
-        volatility_coupling * phi + attributes[node_idx]["tonic_volatility"]
-    ) / (
-        previous_child_variance
-        + jnp.exp(volatility_coupling * phi + attributes[node_idx]["tonic_volatility"])
-    )
+    # Canonical expansion point and its map back to native space
+    ka = volatility_coupling
+    om = attributes[node_idx]["tonic_volatility"]
+    phi_canon = jnp.log(previous_child_variance * (2 + jnp.sqrt(3.0)))
+    phi_full = (phi_canon - om) / ka
+
+    # At phi_full, exp(ka*phi_full + om) = previous_child_variance*(2+sqrt(3))
+    # by construction — use this directly to avoid numerical round-trips
+    exp_at_phi = previous_child_variance * (2 + jnp.sqrt(3.0))
+
+    w_phi = exp_at_phi / (previous_child_variance + exp_at_phi)
 
     delta_phi = (
         (1 / attributes[node_idx]["precision"])
         + (attributes[node_idx]["mean"] - attributes[node_idx]["expected_mean"]) ** 2
-    ) / (
-        previous_child_variance
-        + jnp.exp(volatility_coupling * phi + attributes[node_idx]["tonic_volatility"])
-    ) - 1.0
+    ) / (previous_child_variance + exp_at_phi) - 1.0
 
-    pi_l2 = attributes[node_idx][
-        "expected_precision_vol"
-    ] + 0.5 * volatility_coupling**2 * w_phi * (w_phi + (2 * w_phi - 1) * delta_phi)
+    pi_l2 = attributes[node_idx]["expected_precision_vol"] + 0.5 * ka**2 * w_phi * (
+        w_phi + (2 * w_phi - 1) * delta_phi
+    )
 
     mu_hat_phi = (
-        (2.0 * pi_l2 - 1.0) * phi + attributes[node_idx]["expected_mean_vol"]
-    ) / (2.0 * pi_l2)
+        (pi_l2 - attributes[node_idx]["expected_precision_vol"]) * phi_full
+        + attributes[node_idx]["expected_precision_vol"]
+        * attributes[node_idx]["expected_mean_vol"]
+    ) / pi_l2
 
-    mu_l2 = mu_hat_phi + ((volatility_coupling * w_phi) / (2 * pi_l2)) * delta_phi
+    mu_l2 = mu_hat_phi + ((ka * w_phi) / (2 * pi_l2)) * delta_phi
 
     # ----------------------------------------------------------------------------------
     # Compute the full quadratic approximation
     # ----------------------------------------------------------------------------------
-    theta_l = jnp.sqrt(
-        1.2
-        * (
-            (
-                (1 / attributes[node_idx]["precision"])
-                + (attributes[node_idx]["mean"] - attributes[node_idx]["expected_mean"])
-                ** 2
-            )
-            / (previous_child_variance * pi_l1)
-        )
-    )
+
+    # Total posterior uncertainty at child level (be_aux in the Matlab code)
+    be_aux = (1 / attributes[node_idx]["precision"]) + (
+        attributes[node_idx]["mean"] - attributes[node_idx]["expected_mean"]
+    ) ** 2
+
+    # Blending operates in canonical exponent space y = ka * muhat + om
+    y_pred = ka * attributes[node_idx]["expected_mean_vol"] + om
+    theta_l = -jnp.sqrt(1.2 * 2.0 * be_aux / previous_child_variance)
 
     # Compute the weighting of the two approximations
     # using the smoothed rectangular function b
     weighting = smoothed_rectangular(
-        x=attributes[node_idx]["expected_mean_vol"],
+        x=y_pred,
         theta_l=theta_l,
         phi_l=8.0,
         theta_r=0.0,

--- a/pyhgf/updates/vectorized/volatile/prediction_error.py
+++ b/pyhgf/updates/vectorized/volatile/prediction_error.py
@@ -254,37 +254,47 @@ def vectorized_layer_volatility_posterior_unbounded(
     # ------------------------------------------------------------------
     # Second quadratic approximation L2
     # ------------------------------------------------------------------
-    phi = jnp.log(previous_child_variance * (2.0 + jnp.sqrt(3.0)))
 
-    w_phi = jnp.exp(vol_coupling * phi + params.tonic_volatility) / (
-        previous_child_variance + jnp.exp(vol_coupling * phi + params.tonic_volatility)
-    )
+    # Canonical expansion point and its map back to native space
+    ka = vol_coupling
+    om = params.tonic_volatility
+    phi_canon = jnp.log(previous_child_variance * (2.0 + jnp.sqrt(3.0)))
+    phi_full = (phi_canon - om) / ka
+
+    # At phi_full, exp(ka*phi_full + om) = previous_child_variance*(2+sqrt(3))
+    # by construction — use this directly to avoid numerical round-trips
+    exp_at_phi = previous_child_variance * (2.0 + jnp.sqrt(3.0))
+
+    w_phi = exp_at_phi / (previous_child_variance + exp_at_phi)
 
     delta_phi = ((1.0 / layer.precision) + (layer.mean - layer.expected_mean) ** 2) / (
-        previous_child_variance + jnp.exp(vol_coupling * phi + params.tonic_volatility)
+        previous_child_variance + exp_at_phi
     ) - 1.0
 
-    pi_l2 = layer.expected_precision_vol + 0.5 * vol_coupling**2 * w_phi * (
+    pi_l2 = layer.expected_precision_vol + 0.5 * ka**2 * w_phi * (
         w_phi + (2.0 * w_phi - 1.0) * delta_phi
     )
 
-    mu_hat_phi = ((2.0 * pi_l2 - 1.0) * phi + layer.expected_mean_vol) / (2.0 * pi_l2)
+    mu_hat_phi = (
+        (pi_l2 - layer.expected_precision_vol) * phi_full
+        + layer.expected_precision_vol * layer.expected_mean_vol
+    ) / pi_l2
 
-    mu_l2 = mu_hat_phi + ((vol_coupling * w_phi) / (2.0 * pi_l2)) * delta_phi
+    mu_l2 = mu_hat_phi + ((ka * w_phi) / (2.0 * pi_l2)) * delta_phi
 
     # ------------------------------------------------------------------
     # Full quadratic approximation: weighted combination of L1 and L2
     # ------------------------------------------------------------------
-    theta_l = jnp.sqrt(
-        1.2
-        * (
-            ((1.0 / layer.precision) + (layer.mean - layer.expected_mean) ** 2)
-            / (previous_child_variance * pi_l1)
-        )
-    )
+
+    # Total posterior uncertainty at child level (be_aux in the Matlab code)
+    be_aux = (1.0 / layer.precision) + (layer.mean - layer.expected_mean) ** 2
+
+    # Blending operates in canonical exponent space y = ka * muhat + om
+    y_pred = ka * layer.expected_mean_vol + om
+    theta_l = -jnp.sqrt(1.2 * 2.0 * be_aux / previous_child_variance)
 
     weighting = smoothed_rectangular(
-        x=layer.expected_mean_vol,
+        x=y_pred,
         theta_l=theta_l,
         phi_l=8.0,
         theta_r=0.0,

--- a/src/updates/posterior/continuous.rs
+++ b/src/updates/posterior/continuous.rs
@@ -188,19 +188,30 @@ pub fn posterior_update_continuous_state_node_unbounded(network: &mut Network, n
     let mu_l1 = expected_mean + (vol_coupling * w_child / (2.0 * pi_l1)) * delta_child;
 
     // Second quadratic approximation L2
-    let phi = (previous_child_variance * (2.0 + 3.0_f64.sqrt())).ln();
-    let exp_kappa_phi = (vol_coupling * phi + child_tonic_volatility).clamp(-80.0, 80.0).exp();
-    let w_phi = exp_kappa_phi / (previous_child_variance + exp_kappa_phi);
-    let delta_phi = numerator / (previous_child_variance + exp_kappa_phi) - 1.0;
+    // Canonical expansion point and its map back to native space
+    let ka = vol_coupling;
+    let om = child_tonic_volatility;
+    let phi_canon = (previous_child_variance * (2.0 + 3.0_f64.sqrt())).ln();
+    let phi_full = (phi_canon - om) / ka;
+
+    // At phi_full, exp(ka*phi_full + om) = previous_child_variance*(2+sqrt(3))
+    // by construction — use this directly to avoid numerical round-trips
+    let exp_at_phi = previous_child_variance * (2.0 + 3.0_f64.sqrt());
+
+    let w_phi = exp_at_phi / (previous_child_variance + exp_at_phi);
+    let delta_phi = numerator / (previous_child_variance + exp_at_phi) - 1.0;
 
     let pi_l2 = expected_precision
-        + 0.5 * vol_coupling.powi(2) * w_phi * (w_phi + (2.0 * w_phi - 1.0) * delta_phi);
-    let mu_hat_phi = ((2.0 * pi_l2 - 1.0) * phi + expected_mean) / (2.0 * pi_l2);
-    let mu_l2 = mu_hat_phi + (vol_coupling * w_phi / (2.0 * pi_l2)) * delta_phi;
+        + 0.5 * ka.powi(2) * w_phi * (w_phi + (2.0 * w_phi - 1.0) * delta_phi);
+    let mu_hat_phi = ((pi_l2 - expected_precision) * phi_full + expected_precision * expected_mean) / pi_l2;
+    let mu_l2 = mu_hat_phi + (ka * w_phi / (2.0 * pi_l2)) * delta_phi;
 
     // Full quadratic approximation
-    let theta_l = (1.2 * numerator / (previous_child_variance * pi_l1)).sqrt();
-    let weighting = b(expected_mean, theta_l, 8.0, 0.0, 1.0);
+    // Blending operates in canonical exponent space y = ka * muhat + om
+    let be_aux = numerator;
+    let y_pred = ka * expected_mean + om;
+    let theta_l = -(1.2 * 2.0 * be_aux / previous_child_variance).sqrt();
+    let weighting = b(y_pred, theta_l, 8.0, 0.0, 1.0);
 
     let posterior_precision = (1.0 - weighting) * pi_l1 + weighting * pi_l2;
     let posterior_mean = (1.0 - weighting) * mu_l1 + weighting * mu_l2;

--- a/src/updates/prediction_error/volatile.rs
+++ b/src/updates/prediction_error/volatile.rs
@@ -150,19 +150,30 @@ fn unbounded_volatility_level_update(network: &Network, node_idx: usize) -> (f64
         + (volatility_coupling * w_child / (2.0 * pi_l1)) * delta_child;
 
     // Second quadratic approximation L2
-    let phi = (previous_child_variance * (2.0 + 3.0_f64.sqrt())).ln();
-    let exp_kappa_phi = (volatility_coupling * phi + tonic_volatility).clamp(-80.0, 80.0).exp();
-    let w_phi = exp_kappa_phi / (previous_child_variance + exp_kappa_phi);
-    let delta_phi = numerator / (previous_child_variance + exp_kappa_phi) - 1.0;
+    // Canonical expansion point and its map back to native space
+    let ka = volatility_coupling;
+    let om = tonic_volatility;
+    let phi_canon = (previous_child_variance * (2.0 + 3.0_f64.sqrt())).ln();
+    let phi_full = (phi_canon - om) / ka;
+
+    // At phi_full, exp(ka*phi_full + om) = previous_child_variance*(2+sqrt(3))
+    // by construction — use this directly to avoid numerical round-trips
+    let exp_at_phi = previous_child_variance * (2.0 + 3.0_f64.sqrt());
+
+    let w_phi = exp_at_phi / (previous_child_variance + exp_at_phi);
+    let delta_phi = numerator / (previous_child_variance + exp_at_phi) - 1.0;
 
     let pi_l2 = expected_precision_vol
-        + 0.5 * volatility_coupling.powi(2) * w_phi * (w_phi + (2.0 * w_phi - 1.0) * delta_phi);
-    let mu_hat_phi = ((2.0 * pi_l2 - 1.0) * phi + expected_mean_vol) / (2.0 * pi_l2);
-    let mu_l2 = mu_hat_phi + (volatility_coupling * w_phi / (2.0 * pi_l2)) * delta_phi;
+        + 0.5 * ka.powi(2) * w_phi * (w_phi + (2.0 * w_phi - 1.0) * delta_phi);
+    let mu_hat_phi = ((pi_l2 - expected_precision_vol) * phi_full + expected_precision_vol * expected_mean_vol) / pi_l2;
+    let mu_l2 = mu_hat_phi + (ka * w_phi / (2.0 * pi_l2)) * delta_phi;
 
     // Full quadratic approximation
-    let theta_l = (1.2 * numerator / (previous_child_variance * pi_l1)).sqrt();
-    let weighting = b_func(expected_mean_vol, theta_l, 8.0, 0.0, 1.0);
+    // Blending operates in canonical exponent space y = ka * muhat + om
+    let be_aux = numerator;
+    let y_pred = ka * expected_mean_vol + om;
+    let theta_l = -(1.2 * 2.0 * be_aux / previous_child_variance).sqrt();
+    let weighting = b_func(y_pred, theta_l, 8.0, 0.0, 1.0);
 
     let posterior_precision = (1.0 - weighting) * pi_l1 + weighting * pi_l2;
     let posterior_mean = (1.0 - weighting) * mu_l1 + weighting * mu_l2;

--- a/tests/test_updates/posterior/test_posterior_update_continuous.py
+++ b/tests/test_updates/posterior/test_posterior_update_continuous.py
@@ -89,5 +89,5 @@ def test_continuous_posterior_updates():
     new_attributes = continuous_node_posterior_update_unbounded(
         attributes=attributes, node_idx=2, edges=edges
     )
-    assert jnp.isclose(new_attributes[2]["mean"], -0.0019574)
-    assert jnp.isclose(new_attributes[2]["precision"], 1.0088315)
+    assert jnp.isclose(new_attributes[2]["mean"], -0.00210728)
+    assert jnp.isclose(new_attributes[2]["precision"], 1.0088314)


### PR DESCRIPTION
This pull request refactors the quadratic approximation logic for posterior updates in both Python and Rust implementations of the model. The main improvement is a more numerically stable and conceptually clear handling of the canonical expansion point for the second quadratic approximation (L2) in continuous and volatility node updates. The update avoids unnecessary exponentiation and logarithm round-trips, and consistently blends the two approximations in canonical exponent space. Test expectations are also updated to reflect the new, more accurate calculations.

The most important changes are:

**Refactoring of Quadratic Approximation Logic:**

* All posterior update functions in both Python (`pyhgf/updates/posterior/continuous/continuous_node_posterior_update_unbounded.py`, `pyhgf/updates/posterior/volatile/volatile_node_posterior_update_unbounded.py`, `pyhgf/updates/vectorized/volatile/prediction_error.py`) and Rust (`src/updates/posterior/continuous.rs`, `src/updates/prediction_error/volatile.rs`) now explicitly compute the canonical expansion point (`phi_full`) and use a direct calculation for the exponentiated value at this point (`exp_at_phi`). This avoids unnecessary conversions and improves numerical stability. [[1]](diffhunk://#diff-d0b311fe0d068c29e029ca225fbc326f6cca01bb68eeef76618253bc45e6b950L126-R188) [[2]](diffhunk://#diff-be8d3ef86d7b71997788b59cfb3d82fbcd1aac4356ab741dbc5717f4f4485505L77-R123) [[3]](diffhunk://#diff-ed50775fedf77b399c2af299b8a2e20a12b8fe17f85db55a6cd955d5a26f4a4cL257-R297) [[4]](diffhunk://#diff-44ce6fd89d693552574a9e01683d8135c804ff43c259717897b8af9395f90c5dL191-R214) [[5]](diffhunk://#diff-0a6abc2a8f224b20683748bcd15dfac81b999fc3ad829ece5ee4e8297afaf8efL153-R176)

**Consistent Blending in Canonical Exponent Space:**

* The blending of the two quadratic approximations (L1 and L2) now consistently operates in canonical exponent space (`y_pred = ka * muhat + om`), rather than on the mean directly. This change is applied across all affected update functions. [[1]](diffhunk://#diff-d0b311fe0d068c29e029ca225fbc326f6cca01bb68eeef76618253bc45e6b950L126-R188) [[2]](diffhunk://#diff-be8d3ef86d7b71997788b59cfb3d82fbcd1aac4356ab741dbc5717f4f4485505L77-R123) [[3]](diffhunk://#diff-ed50775fedf77b399c2af299b8a2e20a12b8fe17f85db55a6cd955d5a26f4a4cL257-R297) [[4]](diffhunk://#diff-44ce6fd89d693552574a9e01683d8135c804ff43c259717897b8af9395f90c5dL191-R214) [[5]](diffhunk://#diff-0a6abc2a8f224b20683748bcd15dfac81b999fc3ad829ece5ee4e8297afaf8efL153-R176)

**Test Updates:**

* The test for continuous posterior updates in `tests/test_updates/posterior/test_posterior_update_continuous.py` is updated to use the new expected values for mean and precision, reflecting the improved accuracy of the new implementation.