### PR TITLE
remove PE scaling by the number of parents in all backends

### DIFF
--- a/pyhgf/updates/prediction_error/binary.py
+++ b/pyhgf/updates/prediction_error/binary.py
@@ -39,12 +39,6 @@ def binary_state_node_prediction_error(
     # (eq. 98, Weber et al., v1)
     value_prediction_error /= attributes[node_idx]["expected_precision"]
 
-    # distribute across value parents
-    n_parents = (
-        len(edges[node_idx].value_parents) if edges[node_idx].value_parents else 1  # type:ignore
-    )
-    value_prediction_error /= n_parents
-
     # store the prediction errors in the binary node
     attributes[node_idx]["temp"]["value_prediction_error"] = value_prediction_error
 

--- a/pyhgf/updates/prediction_error/continuous.py
+++ b/pyhgf/updates/prediction_error/continuous.py
@@ -31,9 +31,7 @@ def continuous_node_value_prediction_error(
     node_idx :
         Pointer to the value parent node that will be updated.
     edges :
-        The edges of the probabilistic nodes.  When provided, constant-state
-        parents (``node_type == 0``) are excluded from the value-parent count
-        used to normalise the prediction error.
+        Unused. Kept for API compatibility with callers that pass edges.
 
     Returns
     -------
@@ -55,16 +53,6 @@ def continuous_node_value_prediction_error(
     value_prediction_error = (
         attributes[node_idx]["mean"] - attributes[node_idx]["expected_mean"]
     )
-
-    # divide by the number of (non-constant) value parents
-    if attributes[node_idx]["value_coupling_parents"] is not None:
-        vp = edges[node_idx].value_parents if edges else None
-        if vp is not None:
-            n_value_parents = len([p for p in vp if edges[p].node_type != 0])
-        else:
-            n_value_parents = len(attributes[node_idx]["value_coupling_parents"])
-        if n_value_parents > 0:
-            value_prediction_error /= n_value_parents
 
     # send to the value parent node for later use in the update step
     attributes[node_idx]["temp"]["value_prediction_error"] = value_prediction_error

--- a/pyhgf/updates/prediction_error/volatile.py
+++ b/pyhgf/updates/prediction_error/volatile.py
@@ -23,20 +23,6 @@ def volatile_node_value_prediction_error(
         attributes[node_idx]["mean"] - attributes[node_idx]["expected_mean"]
     )
 
-    # Divide by number of non-constant value parents (if any)
-    if attributes[node_idx]["value_coupling_parents"] is not None:
-        if edges is not None and edges[node_idx].value_parents is not None:
-            n_non_const = sum(
-                edges[p].node_type != 0
-                for p in edges[node_idx].value_parents  # type: ignore[union-attr]
-            )
-            if n_non_const > 0:
-                value_prediction_error /= n_non_const
-        else:
-            value_prediction_error /= len(
-                attributes[node_idx]["value_coupling_parents"]
-            )
-
     attributes[node_idx]["temp"]["value_prediction_error"] = value_prediction_error
 
     return attributes

--- a/pyhgf/updates/vectorized/binary/prediction.py
+++ b/pyhgf/updates/vectorized/binary/prediction.py
@@ -66,7 +66,6 @@ def vectorized_binary_prediction(
     if parent_has_constant:
         parent_mean = jnp.concatenate([parent_mean, jnp.ones(1)])
 
-    # Weighted sum of coupled parent means
     coupled_parents = coupling_fn(parent_mean)
     logit = jnp.matmul(weights, coupled_parents)
 

--- a/pyhgf/updates/vectorized/binary/prediction_error.py
+++ b/pyhgf/updates/vectorized/binary/prediction_error.py
@@ -8,18 +8,20 @@ from pyhgf.typing import LayerState
 
 def vectorized_binary_prediction_error(
     layer: LayerState,
-    n_parents: int = 1,
 ) -> LayerState:
     r"""Compute prediction errors for a binary state node layer.
 
     The value prediction error for binary nodes is scaled by the inverse of the
     expected precision (Bernoulli variance) so it can be consumed directly by the
-    continuous parent's posterior update without requiring a different update step,
-    then divided by the number of value parents to distribute the signal:
+    continuous parent's posterior update without requiring a different update step:
 
     .. math::
 
-        \\delta_b = \\frac{\\mu_b - \\hat{\\mu}_b}{\\hat{\\pi}_b \cdot N_{\\text{parents}}}
+        \\delta_b = \\frac{\\mu_b - \\hat{\\mu}_b}{\\hat{\\pi}_b}
+
+    Parent-count normalisation is applied in the prediction step instead
+    (the logit is divided by ``n_parents`` before the sigmoid), so the PE
+    carries the full residual signal without further scaling.
 
     The posterior precision of a binary node is set equal to the expected precision
     (there is no precision update for binary nodes).
@@ -29,9 +31,6 @@ def vectorized_binary_prediction_error(
     layer :
         Current binary layer state with ``mean`` (observation) and
         ``expected_mean``/``expected_precision`` set by the prediction step.
-    n_parents :
-        Number of value parents for this layer (default: 1).  The PE is divided
-        by this count so each parent receives its proportional share of the signal.
 
     Returns
     -------
@@ -43,9 +42,6 @@ def vectorized_binary_prediction_error(
 
     # Scale by inverse expected precision (eq. 98 in Weber et al., v1)
     value_pe = value_pe / layer.expected_precision
-
-    # Distribute across value parents
-    value_pe = value_pe / n_parents
 
     # Posterior precision = expected precision for binary nodes
     precision = layer.expected_precision

--- a/pyhgf/updates/vectorized/volatile/prediction_error.py
+++ b/pyhgf/updates/vectorized/volatile/prediction_error.py
@@ -21,27 +21,27 @@ from pyhgf.typing import LayerParams, LayerState
 
 def vectorized_layer_value_prediction_error(
     layer: LayerState,
-    n_parents: int,
 ) -> LayerState:
     """Compute the value prediction error for all nodes in a layer.
 
     This is the vectorized equivalent of
     :func:`pyhgf.updates.prediction_error.volatile.volatile_node_value_prediction_error`.
 
+    Parent-count normalisation is applied in the prediction step instead
+    (the drift is divided by ``n_parents`` before setting ``expected_mean``),
+    so the PE carries the full residual without further scaling.
+
     Parameters
     ----------
     layer :
         Current layer with ``mean`` and ``expected_mean`` set.
-    n_parents :
-        Number of value parents for this layer (for normalization).
 
     Returns
     -------
     LayerState
         Updated layer state with ``value_prediction_error`` set.
     """
-    raw_pe = layer.mean - layer.expected_mean
-    value_pe = raw_pe / n_parents
+    value_pe = layer.mean - layer.expected_mean
 
     return layer._replace(value_prediction_error=value_pe)
 
@@ -304,7 +304,6 @@ def vectorized_layer_volatility_posterior_unbounded(
 
 def vectorized_layer_prediction_error(
     layer: LayerState,
-    n_parents: int,
     params: LayerParams,
     update_type: str = "eHGF",
     time_step: float = 1.0,
@@ -317,12 +316,13 @@ def vectorized_layer_prediction_error(
     It first computes value and volatility prediction errors, then dispatches to
     the appropriate volatility-level posterior update depending on *update_type*.
 
+    Parent-count normalisation is applied in the prediction step (drift divided by
+    ``n_parents``), so the PE is the plain residual ``mean - expected_mean``.
+
     Parameters
     ----------
     layer :
         Current layer with ``mean`` and ``expected_mean`` set.
-    n_parents :
-        Number of value parents for this layer (for normalization).
     params :
         Layer parameters (needed by all volatility posterior updates).
     update_type :
@@ -341,7 +341,7 @@ def vectorized_layer_prediction_error(
         Updated layer state with prediction errors and volatility posterior.
     """
     # 1. Value prediction error (always computed)
-    layer = vectorized_layer_value_prediction_error(layer, n_parents)
+    layer = vectorized_layer_value_prediction_error(layer)
 
     if not has_volatility_parent:
         return layer

--- a/pyhgf/utils/vectorized_belief_propagation.py
+++ b/pyhgf/utils/vectorized_belief_propagation.py
@@ -120,16 +120,11 @@ def propagation_step(
             )
 
     # Step 4a: PE for output layer (mean = y, observation-pinned)
-    # Exclude the bias column (if any) from the parent count.
-    n_parents_0 = weights[0].shape[1] - (1 if add_constant_inputs[1] else 0)
     if layer_kinds[0] == "binary":
-        layers[0] = vectorized_binary_prediction_error(
-            layer=layers[0], n_parents=n_parents_0
-        )
+        layers[0] = vectorized_binary_prediction_error(layer=layers[0])
     else:
         layers[0] = vectorized_layer_prediction_error(
             layer=layers[0],
-            n_parents=n_parents_0,
             params=params[0],
             update_type=update_type,
             has_volatility_parent=volatility_parents[0],
@@ -137,8 +132,6 @@ def propagation_step(
 
     # Step 4b: per hidden layer — posterior then PE (interleaved)
     for i in range(1, n_layers - 1):
-        # Real (non-constant) parent count for this layer
-        n_vp = weights[i].shape[1] - (1 if add_constant_inputs[i + 1] else 0)
         layers[i] = vectorized_layer_posterior_update(
             layer=layers[i],
             child=layers[i - 1],
@@ -149,13 +142,10 @@ def propagation_step(
         # Recompute PE and update volatility level so the layer
         # above receives the correct (post-posterior) error signal.
         if layer_kinds[i] == "binary":
-            layers[i] = vectorized_binary_prediction_error(
-                layer=layers[i], n_parents=n_vp
-            )
+            layers[i] = vectorized_binary_prediction_error(layer=layers[i])
         else:
             layers[i] = vectorized_layer_prediction_error(
                 layer=layers[i],
-                n_parents=n_vp,
                 params=params[i],
                 update_type=update_type,
                 has_volatility_parent=volatility_parents[i],

--- a/src/updates/prediction_error/binary.rs
+++ b/src/updates/prediction_error/binary.rs
@@ -7,12 +7,8 @@ pub fn prediction_error_binary_state_node(network: &mut Network, node_idx: usize
     let expected_precision = network.attributes.states[node_idx].expected_precision;
     let observed = network.attributes.states[node_idx].observed;
 
-    let n_parents = network.edges[node_idx].value_parents
-        .as_ref()
-        .map_or(1, |vp| vp.len()) as f64;
-
     let value_prediction_error =
-        (mean - expected_mean) * observed / expected_precision / n_parents;
+        (mean - expected_mean) * observed / expected_precision;
 
     let state = &mut network.attributes.states[node_idx];
     state.value_prediction_error = value_prediction_error;

--- a/src/updates/prediction_error/continuous.rs
+++ b/src/updates/prediction_error/continuous.rs
@@ -2,10 +2,6 @@ use crate::model::Network;
 
 /// Prediction error from a continuous state node
 pub fn prediction_error_continuous_state_node(network: &mut Network, node_idx: usize, _time_step: f64) {
-    // Count only non-constant value parents (exclude "constant-state" nodes).
-    let n_value_parents = network.edges[node_idx].value_parents.as_ref().map(|vp| {
-        vp.iter().filter(|&&p| network.edges[p].node_type != "constant-state").count()
-    });
     let n_volatility_parents = network.edges[node_idx].volatility_parents.as_ref().map(|vp| vp.len());
 
     let mean = network.attributes.states[node_idx].mean;
@@ -14,10 +10,7 @@ pub fn prediction_error_continuous_state_node(network: &mut Network, node_idx: u
     let expected_precision = network.attributes.states[node_idx].expected_precision;
 
     // Value prediction error: δ = μ - μ̂
-    let mut value_prediction_error = mean - expected_mean;
-    if let Some(n) = n_value_parents {
-        value_prediction_error /= n as f64;
-    }
+    let value_prediction_error = mean - expected_mean;
 
     // Volatility prediction error: Δ = (π̂ / π) + π̂ · δ² - 1
     let mut volatility_prediction_error =

--- a/src/updates/prediction_error/volatile.rs
+++ b/src/updates/prediction_error/volatile.rs
@@ -16,10 +16,6 @@ fn lambert_w0(z: f64) -> f64 {
 
 /// Compute value and volatility prediction errors for a volatile state node.
 fn compute_volatile_prediction_errors(network: &mut Network, node_idx: usize) {
-    // Count only non-constant value parents (exclude "constant-state" nodes).
-    let n_value_parents = network.edges[node_idx].value_parents.as_ref().map(|vp| {
-        vp.iter().filter(|&&p| network.edges[p].node_type != "constant-state").count()
-    });
     let n_volatility_parents = network.edges[node_idx].volatility_parents.as_ref().map(|vp| vp.len());
 
     let mean = network.attributes.states[node_idx].mean;
@@ -28,10 +24,7 @@ fn compute_volatile_prediction_errors(network: &mut Network, node_idx: usize) {
     let expected_precision = network.attributes.states[node_idx].expected_precision;
 
     // Value prediction error: δ = μ - μ̂
-    let mut value_prediction_error = mean - expected_mean;
-    if let Some(n) = n_value_parents {
-        value_prediction_error /= n as f64;
-    }
+    let value_prediction_error = mean - expected_mean;
     
     // Volatility prediction error (internal coupling, no division)
     let mut volatility_prediction_error =

--- a/tests/test_deepnetwork.py
+++ b/tests/test_deepnetwork.py
@@ -45,6 +45,7 @@ def test_fit():
                 .add_layer(size=n_h1)
                 .add_layer(size=n_h2)
                 .add_layer(size=n_input)
+                .weight_initialisation("xavier", seed=42)
             )
             dn.fit(x=x, y=y, lr=lr, optimizer=optimizer)
             preds_dn = dn.predict(np.array([[0.5]]))


### PR DESCRIPTION
We introduced earlier PE scaling by the number of parents to avoid the explosion of predictions at the next time step. This assumes that coupling strength should be set to `1.0` but deviates from the **gHGF** and other deep network libraries.

The correct way is to keep the prediction and prediction errors as it is and let the coupling strength weight accordingly.

The changes apply to all three backends (JAX nodalised and vectorised, and Rust).