### PR TITLE
add relaxed posterior updates

### DIFF
--- a/pyhgf/updates/posterior/continuous/posterior_update_precision_continuous_node.py
+++ b/pyhgf/updates/posterior/continuous/posterior_update_precision_continuous_node.py
@@ -169,7 +169,13 @@ def precision_update(attributes: dict, edges: Edges, node_idx: int) -> Array:
     precision_weigthed_prediction_error = 0.0
 
     # Value coupling updates - update the precision of a value parent
-    # Using eq. 50 from Weber et al. (2026)
+    # Using eq. 50 from Weber et al. (2026), with the posterior-step
+    # (smoothing) correction: replace π̂_a by π̂_a · (π_a − π̂_a) / π_a — the predicted
+    # precision scaled by the child's bottom-up information ratio. The same factor
+    # applies to both the g'² term and the g''·δ_a term. Reduces to the canonical
+    # formula when the child is fully observed (π_a ≫ π̂_a); returns no contribution
+    # when the child gained no bottom-up information (π_a = π̂_a) — which the canonical
+    # formula incorrectly credits anyway.
     # ----------------------------------------------------------------------------------
     if edges[node_idx].value_children is not None:
         for value_child_idx, value_coupling, coupling_fn in zip(
@@ -194,9 +200,34 @@ def precision_update(attributes: dict, edges: Edges, node_idx: int) -> Array:
                     * value_prediction_error
                 )
 
+            # Effective child precision under the smoothing correction. The Schur
+            # derivation assumes a Gaussian-Gaussian value-coupling edge, so the
+            # correction is only valid when the child carries a Gaussian belief
+            # AND is an interior node (it must itself have run a Gaussian posterior
+            # update against information from below). All other cases — binary
+            # children (type 1), categorical (5), input/constant (0), exponential
+            # family (3), Dirichlet (4), and any Gaussian leaf (types 2/6 with no
+            # children of their own) — are clamped/non-Gaussian and fall back to
+            # the canonical ``π̂_a`` (matching the paper's Limit 3, π_a → ∞).
+            child_node_type = edges[value_child_idx].node_type
+            child_is_gaussian_interior = child_node_type in (2, 6) and (
+                edges[value_child_idx].value_children is not None
+                or edges[value_child_idx].volatility_children is not None
+            )
+            child_expected_precision = attributes[value_child_idx]["expected_precision"]
+            if child_is_gaussian_interior:
+                child_precision = attributes[value_child_idx]["precision"]
+                effective_child_precision = (
+                    child_expected_precision
+                    * (child_precision - child_expected_precision)
+                    / child_precision
+                )
+            else:
+                effective_child_precision = child_expected_precision
+
             # cancel the prediction error if the child value was not observed
             precision_weigthed_prediction_error += (
-                attributes[value_child_idx]["expected_precision"]
+                effective_child_precision
                 * (coupling_fn_prime - coupling_fn_second)
                 * attributes[value_child_idx]["observed"]
             )

--- a/pyhgf/updates/posterior/volatile/posterior_update_value_level.py
+++ b/pyhgf/updates/posterior/volatile/posterior_update_value_level.py
@@ -16,7 +16,16 @@ def posterior_update_precision_value_level(
 ) -> float:
     """Update the precision of the value level using value children's PEs.
 
-    This is similar to continuous node value coupling precision update.
+    Implements the posterior-step (smoothing) correction of the relaxed HGF: the
+    canonical child-precision factor ``π̂_a`` is replaced by
+    ``π̂_a · (π_a − π̂_a) / π_a`` — the predicted precision scaled by the child's
+    bottom-up information ratio. The same factor applies to both the ``g'²`` and the
+    ``g''·δ_a`` contributions. Reduces to the canonical formula when the child is fully
+    observed; returns no contribution when the child gained no bottom-up information.
+
+    A child with no children of its own is an input: pyhgf's convention keeps
+    ``precision = expected_precision`` for such nodes, so the smoothing form would zero
+    out their contribution. Fall back to the canonical ``π̂_a``.
 
     .. note::
 
@@ -36,12 +45,32 @@ def posterior_update_precision_value_level(
             attributes[node_idx]["value_coupling_children"],
             edges[node_idx].coupling_fn,
         ):
-            # Get child's expected precision
+            # Effective child precision under the smoothing correction. The Schur
+            # derivation assumes a Gaussian-Gaussian value-coupling edge, so the
+            # correction applies only when the child carries a Gaussian belief
+            # (continuous-state type 2 or volatile-state type 6) AND is interior
+            # (has children of its own). Binary, categorical, input/constant,
+            # exponential family, and Dirichlet children, plus any Gaussian leaf,
+            # fall back to the canonical ``π̂_a``.
+            child_node_type = edges[value_child_idx].node_type
+            child_is_gaussian_interior = child_node_type in (2, 6) and (
+                edges[value_child_idx].value_children is not None
+                or edges[value_child_idx].volatility_children is not None
+            )
             child_expected_precision = attributes[value_child_idx]["expected_precision"]
+            if child_is_gaussian_interior:
+                child_precision = attributes[value_child_idx]["precision"]
+                effective_child_precision = (
+                    child_expected_precision
+                    * (child_precision - child_expected_precision)
+                    / child_precision
+                )
+            else:
+                effective_child_precision = child_expected_precision
 
             # Linear coupling
             if coupling_fn is None:
-                posterior_precision += (value_coupling**2) * child_expected_precision
+                posterior_precision += (value_coupling**2) * effective_child_precision
             else:
                 # Non-linear coupling (with gradient)
                 coupling_fn_prime = grad(coupling_fn)(
@@ -52,7 +81,7 @@ def posterior_update_precision_value_level(
                 )
                 value_pe = attributes[value_child_idx]["temp"]["value_prediction_error"]
 
-                posterior_precision += child_expected_precision * (
+                posterior_precision += effective_child_precision * (
                     (value_coupling**2) * (coupling_fn_prime**2)
                     - value_coupling * coupling_fn_second * value_pe
                 )

--- a/pyhgf/updates/vectorized/volatile/posterior.py
+++ b/pyhgf/updates/vectorized/volatile/posterior.py
@@ -17,11 +17,30 @@ def vectorized_posterior_update_precision_value_level(
     child: LayerState,
     weights: jnp.ndarray,
     coupling_fn_grad: Callable,
+    child_is_input_layer: bool = False,
 ) -> jnp.ndarray:
-    """Update the precision of the value level for all nodes in a layer.
+    r"""Update the precision of the value level for all nodes in a layer.
 
     This is the vectorized equivalent of
     :func:`pyhgf.updates.posterior.volatile.posterior_update_value_level.posterior_update_precision_value_level`.
+
+    Implements the *posterior-step (smoothing) correction* of the relaxed HGF on
+    value-coupling edges. Lifting the mean-field delta-collapse approximation
+    :math:`q(x_a, x_b) = q(x_a)\,q(x_b)` to a structured Gaussian on the value-coupling
+    edge and applying the Schur complement yields the substitution
+
+    .. math::
+
+        \hat\pi_a^{(k)} \;\longmapsto\;
+        \hat\pi_a^{(k)} \, \frac{\pi_a^{(k)} - \hat\pi_a^{(k)}}{\pi_a^{(k)}}
+
+    in the canonical value-coupling contribution to :math:`\pi_b^{(k)}`. The
+    multiplicative factor :math:`(\pi_a - \hat\pi_a)/\pi_a \in [0, 1]` is the fraction
+    of the child's posterior precision attributable to bottom-up evidence (rather than
+    to its own predicted prior). The same factor scales both the :math:`g'^2` and the
+    :math:`g''\,\delta_a` contributions. Reduces to the canonical formula when the child
+    is fully observed (:math:`\pi_a \gg \hat\pi_a`); returns no update when the child
+    gained no bottom-up information (:math:`\pi_a = \hat\pi_a`).
 
     .. note::
 
@@ -42,6 +61,16 @@ def vectorized_posterior_update_precision_value_level(
         ``(n_children, n_parents)``.
     coupling_fn_grad :
         Gradient of the coupling function.
+    child_is_input_layer :
+        If True, the child is the clamped observation leaf (binary or
+        continuous output). In that case the paper's Limit 3 applies
+        (``π_a → ∞``) and the smoothing correction reduces to the canonical
+        contribution ``π̂_a``. We bypass the ``(π_a − π̂_a)/π_a`` formula
+        here because pyhgf's leaf convention sets ``π_a = π̂_a`` for the
+        binary PE and never updates ``π_a`` for a continuous leaf — neither
+        signals "info gained", so the smoothing form would incorrectly
+        zero out the leaf's contribution. Defaults to ``False`` (interior
+        child, full smoothing correction).
 
     Returns
     -------
@@ -54,14 +83,39 @@ def vectorized_posterior_update_precision_value_level(
     # Coupling second derivative (for second-order EKF correction)
     coupling_second = vmap(jgrad(coupling_fn_grad))(layer.expected_mean)
 
-    # First-order term: sum_i(w_ij^2 * child_prec_i) * f'(m_j)^2
-    precision_contrib_1 = jnp.matmul(weights.T**2, child.expected_precision) * (
+    # Effective child precision under the smoothing correction:
+    #     π̂_a · (π_a − π̂_a) / π_a
+    # By the time this kernel runs for an interior child, the child layer's
+    # bottom-up posterior update has already populated ``child.precision``;
+    # the prediction-step value remains in ``child.expected_precision``.
+    # Their difference (π_a − π̂_a) is the information actually gained at the
+    # child during the bottom-up sweep — exactly the quantity the
+    # structured-Gaussian + Schur derivation identifies as the fresh
+    # evidence the parent should be credited with.
+    #
+    # For a clamped leaf (binary/continuous observation layer), pyhgf's
+    # representational convention does not store the "infinite" posterior
+    # precision that the observation logically carries — ``π_a`` stays
+    # equal to ``π̂_a``. We therefore short-circuit to the canonical
+    # contribution ``π̂_a``, matching the paper's Limit 3 (``π_a → ∞``).
+    if child_is_input_layer:
+        effective_child_precision = child.expected_precision
+    else:
+        effective_child_precision = (
+            child.expected_precision
+            * (child.precision - child.expected_precision)
+            / child.precision
+        )
+
+    # First-order term: sum_i(w_ij^2 * effective_child_prec_i) * f'(m_j)^2
+    precision_contrib_1 = jnp.matmul(weights.T**2, effective_child_precision) * (
         coupling_prime**2
     )
 
-    # Second-order correction: -f''(m_j) * sum_i(w_ij * child_prec_i * vpe_i)
+    # Second-order correction: -f''(m_j) * sum_i(w_ij * effective_child_prec_i * vpe_i)
+    # The same multiplicative factor (π_a − π̂_a)/π_a applies.
     sum_pi_vpe = jnp.matmul(
-        weights.T, child.expected_precision * child.value_prediction_error
+        weights.T, effective_child_precision * child.value_prediction_error
     )
     precision_contrib_2 = -coupling_second * sum_pi_vpe
 
@@ -133,6 +187,7 @@ def vectorized_layer_posterior_update(
     coupling_fn_grad: Callable,
     parent_has_constant: bool = False,
     max_posterior_precision: float = 1e10,
+    child_is_input_layer: bool = False,
 ) -> LayerState:
     """Update the value-level posterior for all nodes in a parent layer.
 
@@ -157,6 +212,10 @@ def vectorized_layer_posterior_update(
         is stripped before computing the posterior update.
     max_posterior_precision :
         Upper bound applied to the posterior precision. Default ``1e10``.
+    child_is_input_layer :
+        If True, the child is the clamped observation leaf (binary or
+        continuous output). The smoothing correction reduces to the
+        canonical contribution (paper's Limit 3). Defaults to ``False``.
 
     Returns
     -------
@@ -170,7 +229,11 @@ def vectorized_layer_posterior_update(
     # Update precision first, then mean
     posterior_precision = jnp.clip(
         vectorized_posterior_update_precision_value_level(
-            layer, child, weights, coupling_fn_grad
+            layer,
+            child,
+            weights,
+            coupling_fn_grad,
+            child_is_input_layer=child_is_input_layer,
         ),
         a_min=layer.expected_precision,
         a_max=max_posterior_precision,

--- a/pyhgf/utils/vectorized_belief_propagation.py
+++ b/pyhgf/utils/vectorized_belief_propagation.py
@@ -159,6 +159,11 @@ def propagation_step(
             coupling_fn_grad=coupling_fn_grads[i],  # parent i's grad
             parent_has_constant=add_constant_inputs[i],
             max_posterior_precision=max_posterior_precision,
+            # Layer 0 is the observation leaf — its `precision` is the
+            # representational stand-in for a clamped observation, not a
+            # bottom-up posterior gain. Tell the kernel to use the canonical
+            # contribution (paper's Limit 3, π_a → ∞) for that case.
+            child_is_input_layer=(i - 1 == 0),
         )
         # Recompute PE and update volatility level so the layer
         # above receives the correct (post-posterior) error signal.

--- a/src/updates/posterior/continuous.rs
+++ b/src/updates/posterior/continuous.rs
@@ -19,6 +19,21 @@ fn lambert_w0(z: f64) -> f64 {
 // =============================================================================
 
 /// Compute the precision update contribution from value and volatility children.
+///
+/// The value-coupling branch implements the posterior-step (smoothing)
+/// correction of the relaxed HGF: the canonical child-precision factor
+/// `π̂_a` is replaced by `π̂_a · (π_a − π̂_a) / π_a` — the predicted precision
+/// scaled by the child's bottom-up information ratio. The same factor applies
+/// to both the `g'²` and the `g''·δ_a` terms. Reduces to the canonical formula
+/// when the child is fully observed; returns no contribution when the child
+/// gained no bottom-up information.
+///
+/// Boundary leaves (children with no children of their own) are clamped
+/// observations and fall back to the canonical `π̂_a` — pyhgf's convention
+/// keeps `precision = expected_precision` for such nodes, so the smoothing
+/// form would otherwise zero out their contribution.
+///
+/// Volatility coupling is unchanged.
 fn precision_update_from_children(network: &Network, node_idx: usize) -> f64 {
     let mut precision_wpe = 0.0;
 
@@ -44,7 +59,28 @@ fn precision_update_from_children(network: &Network, node_idx: usize) -> f64 {
                 None => (1.0, 0.0),
             };
 
-            precision_wpe += (child_expected_precision
+            // Effective child precision under the smoothing correction. The
+            // Schur derivation assumes a Gaussian-Gaussian value-coupling edge,
+            // so the correction applies only when the child carries a Gaussian
+            // belief (continuous-state or volatile-state) AND is interior (has
+            // children of its own). Binary, categorical, input/constant,
+            // exponential family, and Dirichlet children, plus any Gaussian
+            // leaf, fall back to the canonical `π̂_a` (paper's Limit 3).
+            let child_node_type = network.edges[child_idx].node_type.as_str();
+            let child_is_gaussian_interior =
+                matches!(child_node_type, "continuous-state" | "volatile-state")
+                    && (network.edges[child_idx].value_children.is_some()
+                        || network.edges[child_idx].volatility_children.is_some());
+            let effective_child_precision = if child_is_gaussian_interior {
+                let child_precision = child_state.precision;
+                child_expected_precision
+                    * (child_precision - child_expected_precision)
+                    / child_precision
+            } else {
+                child_expected_precision
+            };
+
+            precision_wpe += (effective_child_precision
                 * (kappa.powi(2) * coupling_fn_prime_sq - coupling_fn_second_term)) * observed;
         }
     }

--- a/src/updates/posterior/volatile.rs
+++ b/src/updates/posterior/volatile.rs
@@ -4,6 +4,13 @@ use crate::model::Network;
 // Value level updates
 // =============================================================================
 
+/// Posterior-step (smoothing) correction of the relaxed HGF: the
+/// canonical child-precision factor `π̂_a` is replaced by
+/// `π̂_a · (π_a − π̂_a) / π_a` — the predicted precision scaled by the
+/// child's bottom-up information ratio. The same factor applies to both the
+/// `g'²` and the `g''·δ_a` terms. Boundary leaves (no children of their own)
+/// fall back to the canonical `π̂_a` since pyhgf's convention keeps
+/// `precision = expected_precision` for such clamped observations.
 fn precision_update_value_level(network: &Network, node_idx: usize) -> f64 {
     let expected_precision = network.attributes.states[node_idx].expected_precision;
     let mut posterior_precision = expected_precision;
@@ -28,7 +35,28 @@ fn precision_update_value_level(network: &Network, node_idx: usize) -> f64 {
                 None => (1.0, 0.0),
             };
 
-            posterior_precision += child_expected_precision
+            // Effective child precision under the smoothing correction. The
+            // Schur derivation assumes a Gaussian-Gaussian value-coupling edge,
+            // so the correction applies only when the child carries a Gaussian
+            // belief (continuous-state or volatile-state) AND is interior (has
+            // children of its own). Binary, categorical, input/constant,
+            // exponential family, and Dirichlet children, plus any Gaussian
+            // leaf, fall back to the canonical `π̂_a`.
+            let child_node_type = network.edges[child_idx].node_type.as_str();
+            let child_is_gaussian_interior =
+                matches!(child_node_type, "continuous-state" | "volatile-state")
+                    && (network.edges[child_idx].value_children.is_some()
+                        || network.edges[child_idx].volatility_children.is_some());
+            let effective_child_precision = if child_is_gaussian_interior {
+                let child_precision = child_state.precision;
+                child_expected_precision
+                    * (child_precision - child_expected_precision)
+                    / child_precision
+            } else {
+                child_expected_precision
+            };
+
+            posterior_precision += effective_child_precision
                 * (kappa.powi(2) * coupling_fn_prime_sq - coupling_fn_second_term);
         }
     }


### PR DESCRIPTION
# Smoothing-corrected posterior precision update for value-coupled parents

## Summary

This PR implements the *posterior-step (smoothing) correction* on value-coupling edges. The canonical (g)HGF posterior collapses the child's variational marginal $q(x_a^{(k)})$ to a delta function at its posterior mean when computing the parent's posterior precision. The child's posterior *mean* enters via $\delta_a^{(k)}$ but the child's posterior *precision* $\pi_a^{(k)}$ does not appear at all. Lifting this delta-collapse and keeping $q(x_a^{(k)})$ Gaussian end-to-end yields a single closed-form correction factor.

## Canonical posterior precision (Weber et al., 2026)

For a continuous value parent $x_b$ with a single value child $x_a$, the canonical update is

$$
\pi_b^{(k)} = \hat{\pi}_b^{(k)} + \hat{\pi}_a^{(k)} \left[ \alpha^{2} g'(\hat{\mu}_b)^{2} - g''(\hat{\mu}_b)  \delta_a^{(k)} \right]
$$

with the mean update

$$
\mu_b^{(k)} = \hat{\mu}_b + \frac{\alpha g'(\hat{\mu}_b) \hat{\pi}_a^{(k)}}{\pi_b^{(k)}} \delta_a^{(k)}.
$$

The factor $\hat{\pi}_a^{(k)}$ multiplying both the $g'^{2}$ and $g''\delta_a$ terms is the child's *predicted* precision, its posterior precision $\pi_a^{(k)}$ does not enter.

## Improved posterior precision (this PR)

Replacing the mean-field $q(x_a, x_b) = q(x_a) q(x_b)$ with a structured Gaussian on the value-coupling edge and marginalising $x_a$ out of the joint via a Schur complement yields the substitution

$$
\hat{\pi}_a^{(k)} \longmapsto \hat{\pi}_a^{(k)} \frac{\pi_a^{(k)} - \hat{\pi}_a^{(k)}}{\pi_a^{(k)}}
$$

applied to **both** the $g'^{2}$ term and the $g''\delta_a$ term:

$$
\boxed{ \pi_b^{(k)} = \hat{\pi}_b^{(k)} +\frac{\hat{\pi}_a^{(k)} \bigl(\pi_a^{(k)} - \hat{\pi}_a^{(k)}\bigr)}{\pi_a^{(k)}} \left[\alpha^{2} g'(\hat{\mu}_b)^{2} - g''(\hat{\mu}_b) \delta_a^{(k)} \right] }
$$

The multiplicative correction factor

$$
\frac{\pi_a^{(k)} - \hat{\pi}_a^{(k)}}{\pi_a^{(k)}} = \frac{\pi_y}{\hat{\pi}_a^{(k)} + \pi_y} \in [0, 1]
$$

is the fraction of the child's posterior precision attributable to **bottom-up evidence** $\pi_y$ rather than to its own predicted prior. The mean update is unchanged in algebraic form, only the denominator picks up the corrected $\pi_b^{(k)}$:

$$
\mu_b^{(k)} = \hat{\mu}_b + \frac{\alpha g'(\hat{\mu}_b) \hat{\pi}_a^{(k)}}{\pi_b^{(k)}} \delta_a^{(k)}.
$$

## When the correction fires

The Schur derivation requires a **Gaussian–Gaussian** value-coupling edge. The substitution is therefore applied only when the child:

- is a continuous-state (`node_type == 2`) or volatile-state (`node_type == 6`) node carrying a Gaussian belief, **and**
- has at least one child of its own (i.e. is an interior Gaussian, with a genuine posterior precision gain from below).

All other children **binary** (`node_type == 1`), **categorical** (`5`), **input/constant** (`0`), **exponential family** (`3`), **Dirichlet** (`4`), and any **Gaussian leaf** of types 2 or 6 with no children fall back to the canonical $\hat{\pi}_a^{(k)}$. Binary observations are conceptually clamped (Limit 3, $\pi_a \to \infty$), and pyhgf's representational convention stores them as $\pi_a = \hat{\pi}_a$ finite. Treating them with the smoothing form would zero out their contributions, which is what was previously breaking the categorical-HGF tests.