### PR TITLE
control volatility and mean-field updates for Network

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
           - --black                     # quote/blankline conventions match ruff-format
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.15.16
+  rev: v0.15.17
   hooks:
     # Run the linter.
     - id: ruff

--- a/docs/source/notebooks/0.5-Deep_learning.ipynb
+++ b/docs/source/notebooks/0.5-Deep_learning.ipynb
@@ -579,7 +579,7 @@
     "    # ``_linear`` is a single shared object: ``coupling_fn`` is a static field,\n",
     "    # so reusing it lets JAX compile ``run_scan`` once and reuse it across the\n",
     "    # whole grid (a fresh ``lambda`` per call would recompile for every state).\n",
-    "    net = DeepNetwork(coupling_fn=_linear, update_type=\"standard\")\n",
+    "    net = DeepNetwork(coupling_fn=_linear, volatility_updates=\"standard\")\n",
     "    for i in range(N_LAYERS):\n",
     "        prec = root_prec if i == 0 else leaf_prec if i == N_LAYERS - 1 else 100.0\n",
     "        # The slider drives the tonic volatility of the interior (hidden) layers\n",

--- a/docs/source/notebooks/Example_3_Multi_armed_bandit.ipynb
+++ b/docs/source/notebooks/Example_3_Multi_armed_bandit.ipynb
@@ -1234,7 +1234,7 @@
    ],
    "source": [
     "with pm.Model() as model:\n",
-    "    tonic_volatility_2 = pm.Normal(\"tonic_volatility_2\", .0, 5.0)\n",
+    "    tonic_volatility_2 = pm.Normal(\"tonic_volatility_2\", 0.0, 5.0)\n",
     "\n",
     "    log_likelihood = pm.CustomDist(\n",
     "        \"log_likelihood\",\n",

--- a/pyhgf/model/deep_network.py
+++ b/pyhgf/model/deep_network.py
@@ -96,7 +96,7 @@ class DeepNetwork:
     def __init__(
         self,
         coupling_fn: Callable = lambda x: x,
-        update_type: str = "unbounded",
+        volatility_updates: str = "unbounded",
         max_posterior_precision: float = 1e10,
     ):
         """Initialize a VectorizedDeepNetwork.
@@ -107,7 +107,7 @@ class DeepNetwork:
             Coupling function applied between layers. Default is linear (identity),
             matching the Rust backend and the Network class. This function is
             applied to parent means before the weighted sum to predict child means.
-        update_type :
+        volatility_updates :
             The type of volatility-level posterior update. Can be ``"unbounded"``
             (default), ``"eHGF"`` or ``"standard"``. Matches the Network
             class and Rust backend.
@@ -118,7 +118,7 @@ class DeepNetwork:
             to be more conservative against precision blow-up.
         """
         self.coupling_fn = coupling_fn
-        self.update_type = update_type
+        self.volatility_updates = volatility_updates
         self.max_posterior_precision = float(max_posterior_precision)
         self.layer_sizes: list[int] = []
         self.layer_kinds: list[str] = []
@@ -393,7 +393,7 @@ class DeepNetwork:
 
         return Network(
             layers=tuple(elements),
-            update_type=self.update_type,
+            volatility_updates=self.volatility_updates,
             max_posterior_precision=self.max_posterior_precision,
         )
 

--- a/pyhgf/model/network.py
+++ b/pyhgf/model/network.py
@@ -73,14 +73,14 @@ class Network:
 
     def __init__(
         self,
-        update_type: str = "unbounded",
+        volatility_updates: str = "unbounded",
         max_posterior_precision: float = 1e10,
     ) -> None:
         """Initialize an empty neural network.
 
         Parameters
         ----------
-        update_type :
+        volatility_updates :
             The type of update to perform for volatility coupling. Can be `"unbounded"`
             (defaults), `"eHGF"` or `"standard"`. The unbounded approximation was
             recently introduced to avoid negative precisions updates, which greatly
@@ -111,7 +111,7 @@ class Network:
         self.input_dim: list = []
         self.action_steps: Optional[Sequence] = None
         self.last_attributes: Optional[Attributes] = None
-        self.update_type = update_type
+        self.volatility_updates = volatility_updates
         self.max_posterior_precision = float(max_posterior_precision)
 
     @property
@@ -166,7 +166,7 @@ class Network:
         # create the update sequence if it does not already exist
         if self.update_sequence is None:
             self.update_sequence = get_update_sequence(
-                network=self, update_type=self.update_type
+                network=self, update_type=self.volatility_updates
             )
 
         # create the belief propagation function
@@ -234,7 +234,7 @@ class Network:
         # create the update sequence if it does not already exist
         if self.update_sequence is None:
             self.update_sequence = get_update_sequence(
-                network=self, update_type=self.update_type
+                network=self, update_type=self.volatility_updates
             )
         # create the learning sequence
         # all nodes except the prediction nodes should update their coupling strengths
@@ -448,7 +448,7 @@ class Network:
         # ensure the update sequence exists
         if self.update_sequence is None:
             self.update_sequence = get_update_sequence(
-                network=self, update_type=self.update_type
+                network=self, update_type=self.volatility_updates
             )
 
         # keep only prediction steps that are not on the predictor nodes

--- a/pyhgf/model/network.py
+++ b/pyhgf/model/network.py
@@ -75,6 +75,7 @@ class Network:
         self,
         volatility_updates: str = "unbounded",
         max_posterior_precision: float = 1e10,
+        mean_field_updates: bool = False,
     ) -> None:
         """Initialize an empty neural network.
 
@@ -98,6 +99,17 @@ class Network:
             nodes). Defaults to ``1e10`` and is shared with the vectorized JAX and Rust
             backends. Increase it to relax the cap, or lower it to be more conservative
             against precision blow-up.
+        mean_field_updates :
+            If ``False`` (default), use the relaxed prediction and posterior updates,
+            which lift the mean-field assumption on value-coupling edges via
+            Schur-complement and Laplace/MGF corrections. If ``True``, use the original
+            mean-field updates from [1]_.
+
+        References
+        ----------
+        .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
+          Mathys, C. (2026). The generalized hierarchical Gaussian filter.
+          doi:10.7554/elife.110174.1
         """
         self.edges: Edges = ()
         self.n_nodes: int = 0  # number of nodes in the network
@@ -112,6 +124,7 @@ class Network:
         self.action_steps: Optional[Sequence] = None
         self.last_attributes: Optional[Attributes] = None
         self.volatility_updates = volatility_updates
+        self.mean_field_updates = mean_field_updates
         self.max_posterior_precision = float(max_posterior_precision)
 
     @property
@@ -166,7 +179,9 @@ class Network:
         # create the update sequence if it does not already exist
         if self.update_sequence is None:
             self.update_sequence = get_update_sequence(
-                network=self, update_type=self.volatility_updates
+                network=self,
+                update_type=self.volatility_updates,
+                mean_field_updates=self.mean_field_updates,
             )
 
         # create the belief propagation function
@@ -234,7 +249,9 @@ class Network:
         # create the update sequence if it does not already exist
         if self.update_sequence is None:
             self.update_sequence = get_update_sequence(
-                network=self, update_type=self.volatility_updates
+                network=self,
+                update_type=self.volatility_updates,
+                mean_field_updates=self.mean_field_updates,
             )
         # create the learning sequence
         # all nodes except the prediction nodes should update their coupling strengths
@@ -448,7 +465,9 @@ class Network:
         # ensure the update sequence exists
         if self.update_sequence is None:
             self.update_sequence = get_update_sequence(
-                network=self, update_type=self.volatility_updates
+                network=self,
+                update_type=self.volatility_updates,
+                mean_field_updates=self.mean_field_updates,
             )
 
         # keep only prediction steps that are not on the predictor nodes

--- a/pyhgf/typing/vectorised.py
+++ b/pyhgf/typing/vectorised.py
@@ -203,7 +203,7 @@ class Network(eqx.Module):
     """
 
     layers: tuple
-    update_type: str = field(static=True)
+    volatility_updates: str = field(static=True)
     max_posterior_precision: float = field(static=True)
 
     @property

--- a/pyhgf/updates/posterior/continuous/__init__.py
+++ b/pyhgf/updates/posterior/continuous/__init__.py
@@ -1,11 +1,19 @@
-from .continuous_node_posterior_update import continuous_node_posterior_update
-from .continuous_node_posterior_update_ehgf import continuous_node_posterior_update_ehgf
+from .continuous_node_posterior_update import (
+    continuous_node_posterior_update,
+    continuous_node_posterior_update_mean_field,
+)
+from .continuous_node_posterior_update_ehgf import (
+    continuous_node_posterior_update_ehgf,
+    continuous_node_posterior_update_ehgf_mean_field,
+)
 from .continuous_node_posterior_update_unbounded import (
     continuous_node_posterior_update_unbounded,
 )
 
 __all__ = [
-    "continuous_node_posterior_update_ehgf",
     "continuous_node_posterior_update",
+    "continuous_node_posterior_update_mean_field",
+    "continuous_node_posterior_update_ehgf",
+    "continuous_node_posterior_update_ehgf_mean_field",
     "continuous_node_posterior_update_unbounded",
 ]

--- a/pyhgf/updates/posterior/continuous/continuous_node_posterior_update.py
+++ b/pyhgf/updates/posterior/continuous/continuous_node_posterior_update.py
@@ -7,9 +7,13 @@ from jax import jit
 
 from pyhgf.typing import Edges
 
-from .posterior_update_mean_continuous_node import posterior_update_mean_continuous_node
+from .posterior_update_mean_continuous_node import (
+    posterior_update_mean_continuous_node,
+    posterior_update_mean_continuous_node_mean_field,
+)
 from .posterior_update_precision_continuous_node import (
     posterior_update_precision_continuous_node,
+    posterior_update_precision_continuous_node_mean_field,
 )
 
 
@@ -22,6 +26,59 @@ def continuous_node_posterior_update(
     **args,
 ) -> dict:
     """Update the posterior of a continuous node using the standard HGF update.
+
+    The standard HGF posterior update is a two-step process:
+    1. Update the posterior precision.
+    2. Update the posterior mean and assume that the posterior precision is the value
+    updated in the first step.
+
+    Parameters
+    ----------
+    attributes :
+        The attributes of the probabilistic nodes.
+    node_idx :
+        Pointer to the node that needs to be updated. After continuous updates, the
+        parameters of value and volatility parents (if any) will be different.
+    edges :
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
+    max_posterior_precision :
+        Upper bound applied to the posterior precision write. Default ``1e10``.
+
+    Returns
+    -------
+    attributes :
+        The updated attributes of the probabilistic nodes.
+
+    See Also
+    --------
+    posterior_update_precision_continuous_node, posterior_update_mean_continuous_node
+    """
+    # update the posterior mean and precision
+    posterior_precision = posterior_update_precision_continuous_node(
+        attributes, edges, node_idx
+    )
+    attributes[node_idx]["precision"] = jnp.minimum(
+        posterior_precision, max_posterior_precision
+    )
+
+    attributes[node_idx]["mean"] = posterior_update_mean_continuous_node(
+        attributes, edges, node_idx, node_precision=attributes[node_idx]["precision"]
+    )
+
+    return attributes
+
+
+@partial(jit, static_argnames=("edges", "node_idx", "max_posterior_precision"))
+def continuous_node_posterior_update_mean_field(
+    attributes: dict,
+    node_idx: int,
+    edges: Edges,
+    max_posterior_precision: float = 1e10,
+    **args,
+) -> dict:
+    """Update the posterior of a continuous node using the mean-field standard update.
 
     The standard HGF posterior update is a two-step process:
     1. Update the posterior precision.
@@ -56,19 +113,16 @@ def continuous_node_posterior_update(
     References
     ----------
     .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
-       Mathys, C. (2023). The generalized Hierarchical Gaussian Filter (Version 1).
-       arXiv. https://doi.org/10.48550/ARXIV.2305.10937
+        Mathys, C. (2026). The generalized hierarchical Gaussian filter.
+        doi:10.7554/elife.110174.1
     """
-    # update the posterior mean and precision
-    posterior_precision = posterior_update_precision_continuous_node(
+    posterior_precision = posterior_update_precision_continuous_node_mean_field(
         attributes, edges, node_idx
     )
     attributes[node_idx]["precision"] = jnp.minimum(
         posterior_precision, max_posterior_precision
     )
-
-    attributes[node_idx]["mean"] = posterior_update_mean_continuous_node(
+    attributes[node_idx]["mean"] = posterior_update_mean_continuous_node_mean_field(
         attributes, edges, node_idx, node_precision=attributes[node_idx]["precision"]
     )
-
     return attributes

--- a/pyhgf/updates/posterior/continuous/continuous_node_posterior_update_ehgf.py
+++ b/pyhgf/updates/posterior/continuous/continuous_node_posterior_update_ehgf.py
@@ -7,9 +7,13 @@ from jax import jit
 
 from pyhgf.typing import Edges
 
-from .posterior_update_mean_continuous_node import posterior_update_mean_continuous_node
+from .posterior_update_mean_continuous_node import (
+    posterior_update_mean_continuous_node,
+    posterior_update_mean_continuous_node_mean_field,
+)
 from .posterior_update_precision_continuous_node import (
     posterior_update_precision_continuous_node,
+    posterior_update_precision_continuous_node_mean_field,
 )
 
 
@@ -22,6 +26,72 @@ def continuous_node_posterior_update_ehgf(
     **args,
 ) -> dict:
     """Update the posterior of a continuous node using the eHGF update.
+
+    The eHGF posterior update is a two-step process:
+    1. Update the posterior mean and assume that the posterior precision is equal to
+    the expected precision.
+    2. Update the posterior precision.
+
+    .. note::
+        By updating the mean first, and approximating the precision using the expected,
+        precision, this update step often perform better than the regular update and
+        limit the occurence of negative precision that cause the model to fail under
+        some circumstances
+
+    Parameters
+    ----------
+    attributes :
+        The attributes of the probabilistic nodes.
+    node_idx :
+        Pointer to the node that needs to be updated. After continuous updates, the
+        parameters of value and volatility parents (if any) will be different.
+    edges :
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
+        For each node, the index list value and volatility parents and children.
+    max_posterior_precision :
+        Upper bound applied to the posterior precision write. Default ``1e10``.
+
+    Returns
+    -------
+    attributes :
+        The updated attributes of the probabilistic nodes.
+
+    See Also
+    --------
+    posterior_update_precision_continuous_node, posterior_update_mean_continuous_node
+    """
+    # update the posterior mean and precision using the eHGF update step
+    # we start with the mean update using the expected precision as an approximation
+    posterior_mean = posterior_update_mean_continuous_node(
+        attributes,
+        edges,
+        node_idx,
+        node_precision=attributes[node_idx]["expected_precision"],
+    )
+    attributes[node_idx]["mean"] = posterior_mean
+
+    posterior_precision = posterior_update_precision_continuous_node(
+        attributes,
+        edges,
+        node_idx,
+    )
+    attributes[node_idx]["precision"] = jnp.minimum(
+        posterior_precision, max_posterior_precision
+    )
+
+    return attributes
+
+
+@partial(jit, static_argnames=("edges", "node_idx", "max_posterior_precision"))
+def continuous_node_posterior_update_ehgf_mean_field(
+    attributes: dict,
+    node_idx: int,
+    edges: Edges,
+    max_posterior_precision: float = 1e10,
+    **args,
+) -> dict:
+    """Update the posterior of a continuous node using the eHGF update with mean-field.
 
     The eHGF posterior update is a two-step process:
     1. Update the posterior mean and assume that the posterior precision is equal to
@@ -62,12 +132,10 @@ def continuous_node_posterior_update_ehgf(
     References
     ----------
     .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
-       Mathys, C. (2023). The generalized Hierarchical Gaussian Filter (Version 1).
-       arXiv. https://doi.org/10.48550/ARXIV.2305.10937
+       Mathys, C. (2026). The generalized hierarchical Gaussian filter.
+       doi:10.7554/elife.110174.1
     """
-    # update the posterior mean and precision using the eHGF update step
-    # we start with the mean update using the expected precision as an approximation
-    posterior_mean = posterior_update_mean_continuous_node(
+    posterior_mean = posterior_update_mean_continuous_node_mean_field(
         attributes,
         edges,
         node_idx,
@@ -75,7 +143,7 @@ def continuous_node_posterior_update_ehgf(
     )
     attributes[node_idx]["mean"] = posterior_mean
 
-    posterior_precision = posterior_update_precision_continuous_node(
+    posterior_precision = posterior_update_precision_continuous_node_mean_field(
         attributes,
         edges,
         node_idx,

--- a/pyhgf/updates/posterior/continuous/posterior_update_mean_continuous_node.py
+++ b/pyhgf/updates/posterior/continuous/posterior_update_mean_continuous_node.py
@@ -14,7 +14,7 @@ def posterior_update_mean_continuous_node(
     node_idx: int,
     node_precision: float,
 ) -> float:
-    r"""Update the mean of a state node using value- and volatility-coupling PEs [1]_.
+    r"""Continuous mean update without mean-field approximation.
 
     1. Mean update from value coupling
     ----------------------------------
@@ -87,12 +87,6 @@ def posterior_update_mean_continuous_node(
     See Also
     --------
     posterior_update_precision_continuous_node
-
-    References
-    ----------
-    .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
-       Mathys, C. (2026). The generalized Hierarchical Gaussian Filter. eLife
-       Sciences Publications, Ltd. https://doi.org/10.7554/elife.110174.1
 
     """
     # sum the prediction errors from both value and volatility coupling
@@ -192,6 +186,172 @@ def posterior_update_mean_continuous_node(
 
     # Compute the new posterior mean
     # using value prediction errors from both value and volatility coupling
+    posterior_mean = (
+        attributes[node_idx]["expected_mean"]
+        + value_precision_weigthed_prediction_error
+        + volatility_precision_weigthed_prediction_error
+    )
+
+    return posterior_mean
+
+
+@partial(jit, static_argnames=("edges", "node_idx"))
+def posterior_update_mean_continuous_node_mean_field(
+    attributes: dict,
+    edges: Edges,
+    node_idx: int,
+    node_precision: float,
+) -> float:
+    r"""Continuous mean update with mean-field approximation [1]_.
+
+    1. Mean update from value coupling.
+
+    The new mean of a state node :math:`b` value coupled with other input and/or state
+    nodes :math:`j` at time :math:`k` is given by:
+
+    For linear value coupling:
+
+    .. math::
+        \mu_b^{(k)} =  \hat{\mu}_b^{(k)} + \sum_{j=1}^{N_{children}}
+            \frac{\kappa_j \hat{\pi}_j^{(k)}}{\pi_b} \delta_j^{(k)}
+
+    Where :math:`\kappa_j` is the volatility coupling strength between the child node
+    and the state node and :math:`\delta_j^{(k)}` is the value prediction error that
+    was computed beforehand by
+    :py:func:`pyhgf.updates.prediction_errors.continuous.continuous_node_value_prediction_error`.
+
+    For non-linear value coupling:
+
+    .. math::
+        \mu_b^{(k)} =  \hat{\mu}_b^{(k)} + \sum_{j=1}^{N_{children}}
+            \frac{\kappa_j g'_{j,b}({\mu}_b^{(k-1)}) \hat{\pi}_j^{(k)}}{\pi_b}
+            \delta_j^{(k)}
+
+
+    2. Mean update from volatility coupling.
+
+    The new mean of a state node :math:`b` volatility coupled with other input and/or
+    state nodes :math:`j` at time :math:`k` is given by:
+
+    .. math::
+        \mu_b^{(k)} = \hat{\mu}_b^{(k)} + \frac{1}{2\pi_b}
+          \sum_{j=1}^{N_{children}} \kappa_j \gamma_j^{(k)} \Delta_j^{(k)}
+
+    where :math:`\kappa_j` is the volatility coupling strength between the volatility
+    parent and the volatility children :math:`j` and :math:`\Delta_j^{(k)}` is the
+    volatility prediction error is given by:
+
+    .. math::
+
+        \Delta_j^{(k)} = \frac{\hat{\pi}_j^{(k)}}{\pi_j^{(k)}} +
+        \hat{\pi}_j^{(k)} \left( \delta_j^{(k)} \right)^2 - 1
+
+    with :math:`\delta_j^{(k)}` the value prediction error
+    :math:`\delta_j^{(k)} = \mu_j^{k} - \hat{\mu}_j^{k}`.
+
+    :math:`\gamma_j^{(k)}` is the effective precision of the prediction, given by:
+
+    .. math::
+
+        \gamma_j^{(k)} = \Omega_j^{(k)} \hat{\pi}_j^{(k)}
+
+    with :math:`\Omega_j^{(k)}` the predicted volatility computed in the prediction
+    step :py:func:`pyhgf.updates.prediction.predict_precision`.
+
+    If the child node is a continuous state node, the volatility prediction error
+    :math:`\Delta_j^{(k)}` was computed by
+    :py:func:`pyhgf.updates.prediction_errors.continuous.continuous_node_volatility_prediction_error`.
+
+    Parameters
+    ----------
+    attributes :
+        The attributes of the probabilistic nodes.
+    edges :
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as the node
+        number. For each node, the index lists the value and volatility parents and
+        children.
+    node_idx :
+        Pointer to the value parent node that will be updated.
+    node_precision :
+        The precision of the node. Depending on the kind of volatility update, this
+        value can be the expected precision (ehgf), or the posterior from the update
+        (standard).
+
+    Returns
+    -------
+    posterior_mean :
+        The new posterior mean.
+
+    Notes
+    -----
+    This update step is similar to the one used for the state node, except that it uses
+    the observed value instead of the mean of the child node, and the expected mean of
+    the parent node instead of the expected mean of the child node.
+
+    See Also
+    --------
+    posterior_update_precision_continuous_node
+
+    References
+    ----------
+    .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
+       Mathys, C. (2023). The generalized Hierarchical Gaussian Filter (Version 1).
+       arXiv. https://doi.org/10.48550/ARXIV.2305.10937
+
+    """
+    (
+        value_precision_weigthed_prediction_error,
+        volatility_precision_weigthed_prediction_error,
+    ) = (0.0, 0.0)
+
+    if edges[node_idx].value_children is not None:
+        for value_child_idx, value_coupling, coupling_fn in zip(
+            edges[node_idx].value_children,  # type: ignore
+            attributes[node_idx]["value_coupling_children"],
+            edges[node_idx].coupling_fn,
+        ):
+            value_prediction_error = attributes[value_child_idx]["temp"][
+                "value_prediction_error"
+            ]
+            value_prediction_error *= attributes[value_child_idx]["observed"]
+
+            if coupling_fn is None:
+                coupling_fn_prime = 1
+            else:
+                coupling_fn_prime = grad(coupling_fn)(attributes[node_idx]["mean"])
+
+            value_precision_weigthed_prediction_error += (
+                (
+                    value_coupling
+                    * attributes[value_child_idx]["expected_precision"]
+                    * coupling_fn_prime
+                )
+                / node_precision
+            ) * value_prediction_error
+
+    if edges[node_idx].volatility_children is not None:
+        for volatility_child_idx, volatility_coupling in zip(
+            edges[node_idx].volatility_children,  # type: ignore
+            attributes[node_idx]["volatility_coupling_children"],
+        ):
+            volatility_prediction_error = attributes[volatility_child_idx]["temp"][
+                "volatility_prediction_error"
+            ]
+            effective_precision = attributes[volatility_child_idx]["temp"][
+                "effective_precision"
+            ]
+            precision_weigthed_prediction_error = (
+                volatility_coupling * effective_precision * volatility_prediction_error
+            )
+            precision_weigthed_prediction_error *= 1 / (2 * node_precision)
+            precision_weigthed_prediction_error *= attributes[volatility_child_idx][
+                "observed"
+            ]
+            volatility_precision_weigthed_prediction_error += (
+                precision_weigthed_prediction_error
+            )
+
     posterior_mean = (
         attributes[node_idx]["expected_mean"]
         + value_precision_weigthed_prediction_error

--- a/pyhgf/updates/posterior/continuous/posterior_update_precision_continuous_node.py
+++ b/pyhgf/updates/posterior/continuous/posterior_update_precision_continuous_node.py
@@ -94,11 +94,6 @@ def posterior_update_precision_continuous_node(
     posterior_precision :
         The new posterior precision.
 
-    Notes
-    -----
-    This update step is similar to the one used for the state node, except that it uses
-    the observed value instead of the mean of the child node, and the expected mean of
-    the parent node instead of the expected mean of the child node.
 
     See Also
     --------
@@ -107,8 +102,8 @@ def posterior_update_precision_continuous_node(
     References
     ----------
     .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
-       Mathys, C. (2026). The generalized Hierarchical Gaussian Filter. eLife Sciences
-       Publications, Ltd. https://doi.org/10.7554/elife.110174.1
+       Mathys, C. (2026). The generalized hierarchical Gaussian filter.
+       doi:10.7554/elife.110174.1
 
     """
     # ----------------------------------------------------------------------------------
@@ -144,9 +139,9 @@ def precision_update(attributes: dict, edges: Edges, node_idx: int) -> Array:
     r"""Compute new precision in the case of observed values.
 
     Applies the canonical value- and volatility-coupling posterior-precision updates
-    (eq. 50 of Weber et al. (2026) [1]_), augmented by the *relaxed* posterior-step
-    (smoothing) correction on each Gaussian-interior value child: the child-precision
-    factor :math:`\hat{\pi}_a` is replaced by the harmonic combination
+    (eq. 50 of [1]_), augmented by the *relaxed* posterior-step (smoothing) correction
+    on each Gaussian-interior value child: the child-precision factor
+    :math:`\hat{\pi}_a` is replaced by the harmonic combination.
 
     .. math::
 
@@ -181,8 +176,8 @@ def precision_update(attributes: dict, edges: Edges, node_idx: int) -> Array:
     References
     ----------
     .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
-       Mathys, C. (2026). The generalized Hierarchical Gaussian Filter. eLife
-       Sciences Publications, Ltd. https://doi.org/10.7554/elife.110174.1
+       Mathys, C. (2026). The generalized hierarchical Gaussian filter.
+       doi:10.7554/elife.110174.1
     """
     # sum the prediction errors from both value and volatility coupling
     precision_weigthed_prediction_error = 0.0
@@ -349,3 +344,208 @@ def precision_update_missing_values(
     )
 
     return posterior_precision_missing_values
+
+
+@partial(jit, static_argnames=("edges", "node_idx"))
+def precision_update_mean_field(attributes: dict, edges: Edges, node_idx: int) -> Array:
+    """Compute new precision in the case of observed values.
+
+    Parameters
+    ----------
+    attributes :
+        The attributes of the probabilistic nodes.
+    edges :
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as the number
+        of nodes. For each node, the index lists the value and volatility parents and
+        children.
+    node_idx :
+        Pointer to the value parent node that will be updated.
+    time_step :
+        The time elapsed between this observation and the previous one.
+
+    Returns
+    -------
+    posterior_precision :
+        The new posterior precision when at least one of the children has
+        observed a new value. We then use the regular HGF update for volatility
+        coupling.
+    """
+    precision_weigthed_prediction_error = 0.0
+
+    if edges[node_idx].value_children is not None:
+        for value_child_idx, value_coupling, coupling_fn in zip(
+            edges[node_idx].value_children,  # type: ignore
+            attributes[node_idx]["value_coupling_children"],
+            edges[node_idx].coupling_fn,
+        ):
+            if coupling_fn is None:
+                coupling_fn_prime = value_coupling**2
+                coupling_fn_second = 0
+            else:
+                coupling_fn_prime = (
+                    value_coupling**2
+                    * grad(coupling_fn)(attributes[node_idx]["mean"]) ** 2
+                )
+                value_prediction_error = attributes[value_child_idx]["temp"][
+                    "value_prediction_error"
+                ]
+                coupling_fn_second = (
+                    value_coupling
+                    * grad(grad(coupling_fn))(attributes[node_idx]["mean"])
+                    * value_prediction_error
+                )
+
+            precision_weigthed_prediction_error += (
+                attributes[value_child_idx]["expected_precision"]
+                * (coupling_fn_prime - coupling_fn_second)
+                * attributes[value_child_idx]["observed"]
+            )
+
+    if edges[node_idx].volatility_children is not None:
+        for volatility_child_idx, volatility_coupling in zip(
+            edges[node_idx].volatility_children,  # type: ignore
+            attributes[node_idx]["volatility_coupling_children"],
+        ):
+            effective_precision = attributes[volatility_child_idx]["temp"][
+                "effective_precision"
+            ]
+            volatility_prediction_error = attributes[volatility_child_idx]["temp"][
+                "volatility_prediction_error"
+            ]
+            precision_weigthed_prediction_error += (
+                0.5 * (volatility_coupling * effective_precision) ** 2
+                + (volatility_coupling * effective_precision) ** 2
+                * volatility_prediction_error
+                - 0.5
+                * volatility_coupling**2
+                * effective_precision
+                * volatility_prediction_error
+            ) * attributes[volatility_child_idx]["observed"]
+
+    posterior_precision = (
+        attributes[node_idx]["expected_precision"] + precision_weigthed_prediction_error
+    )
+    posterior_precision = jnp.where(
+        posterior_precision > 1e-128, posterior_precision, jnp.nan
+    )
+    return posterior_precision
+
+
+@partial(jit, static_argnames=("edges", "node_idx"))
+def posterior_update_precision_continuous_node_mean_field(
+    attributes: dict,
+    edges: Edges,
+    node_idx: int,
+) -> float:
+    r"""Update the precision of a state node using the volatility prediction errors.
+
+    #. Precision update from value coupling.
+
+    The new precision of a state node :math:`b` value coupled with other input and/or
+    state nodes :math:`j` at time :math:`k` is given by:
+
+    For linear coupling (default)
+
+    .. math::
+
+            \pi_b^{(k)} = \hat{\pi}_b^{(k)} + \sum_{j=1}^{N_{children}}
+            \kappa_j^2 \hat{\pi}_j^{(k)}
+
+    Where :math:`\kappa_j` is the volatility coupling strength between the child node
+    and the state node and :math:`\delta_j^{(k)}` is the value prediction error that
+    was computed beforehand by
+    :py:func:`pyhgf.updates.prediction_errors.continuous.continuous_node_value_prediction_error`.
+
+    For non-linear value coupling we use equation 50 from [1]_.:
+
+    .. math::
+
+            \pi_b^{(k)} = \hat{\pi}_b^{(k)} + \sum_{j=1}^{N_{children}}
+            \hat{\pi}_j^{(k)} * (\kappa_j^2 * g'_{j,b}(\mu_b^(k-1))^2 -
+            g''_{j,b}(\mu_b^(k-1))*\delta_j)
+
+    #. Precision update from volatility coupling.
+
+    The new precision of a state node :math:`b` volatility coupled with other input
+    and/or state nodes :math:`j` at time :math:`k` is given by:
+
+    .. math::
+
+        \pi_b^{(k)} = \hat{\pi}_b^{(k)} + \sum_{j=1}^{N_{children}}
+        \frac{1}{2} \left( \kappa_j \gamma_j^{(k)} \right) ^2 +
+        \left( \kappa_j \gamma_j^{(k)} \right) ^2 \Delta_j^{(k)} -
+        \frac{1}{2} \kappa_j^2 \gamma_j^{(k)} \Delta_j^{(k)}
+
+    where :math:`\kappa_j` is the volatility coupling strength between the volatility
+    parent and the volatility children :math:`j` and :math:`\Delta_j^{(k)}` is the
+    volatility prediction error given by:
+
+    .. math::
+
+        \Delta_j^{(k)} = \frac{\hat{\pi}_j^{(k)}}{\pi_j^{(k)}} +
+        \hat{\pi}_j^{(k)} \left( \delta_j^{(k)} \right)^2 - 1
+
+    with :math:`\delta_j^{(k)}` the value prediction error
+    :math:`\delta_j^{(k)} = \mu_j^{k} - \hat{\mu}_j^{k}`.
+
+    :math:`\gamma_j^{(k)}` is the effective precision of the prediction, given by:
+
+    .. math::
+
+        \gamma_j^{(k)} = \Omega_j^{(k)} \hat{\pi}_j^{(k)}
+
+    that was computed in the prediction step. See [1]_ for more details.
+
+    Parameters
+    ----------
+    attributes :
+        The attributes of the probabilistic nodes.
+    edges :
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as the number
+        of nodes. For each node, the index lists the value and volatility parents and
+        children.
+    node_idx :
+        Pointer to the value parent node that will be updated.
+    time_step :
+        The time elapsed between this observation and the previous one.
+
+    Returns
+    -------
+    posterior_precision :
+        The new posterior precision.
+
+    Notes
+    -----
+    This update step is similar to the one used for the state node, except that it uses
+    the observed value instead of the mean of the child node, and the expected mean of
+    the parent node instead of the expected mean of the child node.
+
+    See Also
+    --------
+    posterior_update_mean_continuous_node
+
+    References
+    ----------
+    .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
+       Mathys, C. (2026). The generalized Hierarchical Gaussian Filter. eLife Sciences
+       Publications, Ltd. https://doi.org/10.7554/elife.110174.1
+
+    """
+    observations = []
+    if edges[node_idx].value_children is not None:
+        for children_idx in edges[node_idx].value_children:  # type: ignore
+            observations.append(attributes[children_idx]["observed"])
+    if edges[node_idx].volatility_children is not None:
+        for children_idx in edges[node_idx].volatility_children:  # type: ignore
+            observations.append(attributes[children_idx]["observed"])
+    observations = jnp.any(jnp.array(observations))
+
+    posterior_precision = cond(
+        observations,
+        Partial(precision_update_mean_field, edges=edges, node_idx=node_idx),
+        Partial(precision_update_missing_values, edges=edges, node_idx=node_idx),
+        attributes,
+    )
+    return posterior_precision

--- a/pyhgf/updates/posterior/volatile/__init__.py
+++ b/pyhgf/updates/posterior/volatile/__init__.py
@@ -1,5 +1,6 @@
 from .volatile_node_posterior_update import (
     volatile_node_posterior_update,
+    volatile_node_posterior_update_mean_field,
     volatile_node_volatility_posterior_update_standard,
 )
 from .volatile_node_posterior_update_ehgf import (
@@ -11,6 +12,7 @@ from .volatile_node_posterior_update_unbounded import (
 
 __all__ = [
     "volatile_node_posterior_update",
+    "volatile_node_posterior_update_mean_field",
     "volatile_node_posterior_update_ehgf",
     "volatile_node_posterior_update_unbounded",
     "volatile_node_volatility_posterior_update_standard",

--- a/pyhgf/updates/posterior/volatile/posterior_update_value_level.py
+++ b/pyhgf/updates/posterior/volatile/posterior_update_value_level.py
@@ -140,7 +140,7 @@ def posterior_update_mean_value_level(
     node_idx: int,
     node_precision: float,
 ) -> float:
-    r"""Update the mean of the value level using value children's PEs.
+    r"""Update the mean of the value level using value children's PEs (no mean-field).
 
     Uses the joint-Gaussian (RTS-smoother) gain rather than the canonical
     value-coupling gain. Each value child contributes
@@ -238,6 +238,102 @@ def posterior_update_mean_value_level(
             # Accumulate precision-weighted PE
             value_precision_weighted_pe += (
                 (value_coupling * gain_precision * coupling_fn_prime) / node_precision
+            ) * value_pe
+
+    posterior_mean += value_precision_weighted_pe
+
+    return posterior_mean
+
+
+@partial(jit, static_argnames=("edges", "node_idx"))
+def posterior_update_precision_value_level_mean_field(
+    attributes: dict,
+    edges: Edges,
+    node_idx: int,
+) -> float:
+    """Update the precision of the value level using value children's PEs.
+
+    This is similar to continuous node value coupling precision update.
+
+    .. note::
+
+        Unlike the standard continuous-state posterior updates elsewhere in the
+        toolbox, the volatile-state updates evaluate coupling function derivatives
+        at the *expected* mean (i.e. the prediction) rather than the posterior
+        mean. This choice is made to better suit deep learning networks where the
+        prediction serves as the natural reference point for computing updates.
+    """
+    posterior_precision = attributes[node_idx]["expected_precision"]
+
+    if edges[node_idx].value_children is not None:
+        for value_child_idx, value_coupling, coupling_fn in zip(
+            edges[node_idx].value_children,  # type: ignore
+            attributes[node_idx]["value_coupling_children"],
+            edges[node_idx].coupling_fn,
+        ):
+            child_expected_precision = attributes[value_child_idx]["expected_precision"]
+
+            if coupling_fn is None:
+                posterior_precision += (value_coupling**2) * child_expected_precision
+            else:
+                coupling_fn_prime = grad(coupling_fn)(
+                    attributes[node_idx]["expected_mean"]
+                )
+                coupling_fn_second = grad(grad(coupling_fn))(
+                    attributes[node_idx]["expected_mean"]
+                )
+                value_pe = attributes[value_child_idx]["temp"]["value_prediction_error"]
+
+                posterior_precision += child_expected_precision * (
+                    (value_coupling**2) * (coupling_fn_prime**2)
+                    - value_coupling * coupling_fn_second * value_pe
+                )
+
+    return posterior_precision
+
+
+@partial(jit, static_argnames=("edges", "node_idx"))
+def posterior_update_mean_value_level_mean_field(
+    attributes: dict,
+    edges: Edges,
+    node_idx: int,
+    node_precision: float,
+) -> float:
+    """Update the mean of the value level using value children's PEs.
+
+    This is similar to continuous node value coupling mean update.
+
+    .. note::
+
+        Unlike the standard continuous-state posterior updates elsewhere in the
+        toolbox, the volatile-state updates evaluate coupling function derivatives
+        at the *expected* mean (i.e. the prediction) rather than the posterior
+        mean. This choice is made to better suit deep learning networks where the
+        prediction serves as the natural reference point for computing updates.
+    """
+    posterior_mean = attributes[node_idx]["expected_mean"]
+    value_precision_weighted_pe = 0.0
+
+    if edges[node_idx].value_children is not None:
+        for value_child_idx, value_coupling, coupling_fn in zip(
+            edges[node_idx].value_children,  # type: ignore
+            attributes[node_idx]["value_coupling_children"],
+            edges[node_idx].coupling_fn,
+        ):
+            value_pe = attributes[value_child_idx]["temp"]["value_prediction_error"]
+
+            if coupling_fn is None:
+                coupling_fn_prime = 1
+            else:
+                coupling_fn_prime = grad(coupling_fn)(
+                    attributes[node_idx]["expected_mean"]
+                )
+
+            child_expected_precision = attributes[value_child_idx]["expected_precision"]
+
+            value_precision_weighted_pe += (
+                (value_coupling * child_expected_precision * coupling_fn_prime)
+                / node_precision
             ) * value_pe
 
     posterior_mean += value_precision_weighted_pe

--- a/pyhgf/updates/posterior/volatile/volatile_node_posterior_update.py
+++ b/pyhgf/updates/posterior/volatile/volatile_node_posterior_update.py
@@ -10,7 +10,9 @@ from pyhgf.typing import Edges
 
 from .posterior_update_value_level import (
     posterior_update_mean_value_level,
+    posterior_update_mean_value_level_mean_field,
     posterior_update_precision_value_level,
+    posterior_update_precision_value_level_mean_field,
 )
 from .posterior_update_volatility_level import (
     posterior_update_mean_volatility_level,
@@ -101,5 +103,51 @@ def volatile_node_volatility_posterior_update_standard(
         attributes, node_idx, precision_vol
     )
     attributes[node_idx]["mean_vol"] = mean_vol
+
+    return attributes
+
+
+@partial(jit, static_argnames=("edges", "node_idx", "max_posterior_precision"))
+def volatile_node_posterior_update_mean_field(
+    attributes: dict,
+    edges: Edges,
+    node_idx: int,
+    max_posterior_precision: float = 1e10,
+) -> dict:
+    """Update a volatile node and the implied volatility parent with mean-field.
+
+    Unlike the standard continuous-state posterior updates elsewhere in the toolbox,
+    the volatile-state updates use the *expected* mean (i.e. the prediction) as the
+    reference point rather than the posterior mean. This choice is made to better suit
+    deep learning networks where the prediction serves as the natural reference for
+    computing updates.
+
+    Parameters
+    ----------
+    attributes :
+        The attributes of the probabilistic nodes.
+    edges :
+        The edges of the probabilistic nodes as a tuple of
+        :py:class:`pyhgf.typing.Indexes`.
+    node_idx :
+        Pointer to the volatile node that needs to be updated.
+    max_posterior_precision :
+        Upper bound applied to the value-level posterior precision write.
+        Default ``1e10``.
+    """
+    precision_value = posterior_update_precision_value_level_mean_field(
+        attributes, edges, node_idx
+    )
+    precision_value = jnp.clip(
+        precision_value,
+        a_min=attributes[node_idx]["expected_precision"],
+        a_max=max_posterior_precision,
+    )
+    attributes[node_idx]["precision"] = precision_value
+
+    mean_value = posterior_update_mean_value_level_mean_field(
+        attributes, edges, node_idx, precision_value
+    )
+    attributes[node_idx]["mean"] = mean_value
 
     return attributes

--- a/pyhgf/updates/prediction/continuous.py
+++ b/pyhgf/updates/prediction/continuous.py
@@ -63,8 +63,8 @@ def predict_mean(
     References
     ----------
     .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
-       Mathys, C. (2023). The generalized Hierarchical Gaussian Filter (Version 1).
-       arXiv. https://doi.org/10.48550/ARXIV.2305.10937
+       Mathys, C. (2026). The generalized hierarchical Gaussian filter.
+       doi:10.7554/elife.110174.1
 
     """
     time_step = attributes[-1]["time_step"]
@@ -107,7 +107,7 @@ def predict_mean(
 def predict_precision(
     attributes: dict, edges: Edges, node_idx: int
 ) -> tuple[Array, Array, Array]:
-    r"""Compute the predicted precisions of a continuous state node.
+    r"""Compute the predicted precisions of a continuous state node (no mean-field).
 
     This is the *improved* (piHGF) prediction step, which marginalises over the parents'
     variational Gaussians rather than collapsing them to point estimates. Two additional
@@ -195,8 +195,8 @@ def predict_precision(
     References
     ----------
     .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
-       Mathys, C. (2026). The generalized Hierarchical Gaussian Filter. eLife
-       Sciences Publications, Ltd. https://doi.org/10.7554/elife.110174.1
+       Mathys, C. (2026). The generalized hierarchical Gaussian filter.
+       doi:10.7554/elife.110174.1
     """
     time_step = attributes[-1]["time_step"]
 
@@ -322,8 +322,8 @@ def continuous_node_prediction(
     References
     ----------
     .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
-       Mathys, C. (2023). The generalized Hierarchical Gaussian Filter (Version 1).
-       arXiv. https://doi.org/10.48550/ARXIV.2305.10937
+       Mathys, C. (2026). The generalized hierarchical Gaussian filter.
+       doi:10.7554/elife.110174.1
     """
     # if this node has volatility parent(s), store the current variance
     # to be used by the posterior update if using unbounded approximation
@@ -355,6 +355,135 @@ def continuous_node_prediction(
         ]["precision"]
 
     # 2. regular continuous state node, or input with volatility parent
+    else:
+        attributes[node_idx]["expected_precision"] = expected_precision
+        attributes[node_idx]["temp"]["conditional_expected_precision"] = (
+            conditional_expected_precision
+        )
+
+    attributes[node_idx]["temp"]["effective_precision"] = effective_precision
+    attributes[node_idx]["expected_mean"] = expected_mean
+
+    return attributes
+
+
+@partial(jit, static_argnames=("edges", "node_idx"))
+def predict_precision_mean_field(
+    attributes: dict, edges: Edges, node_idx: int
+) -> tuple[Array, Array, Array]:
+    r"""Compute the expected precision of a continuous state node (mean-field).
+
+    The expected precision at time :math:`k` for a state node :math:`a` is given by
+    [1]_:
+
+    .. math::
+
+        \hat{\pi}_a^{(k)} = \frac{1}{\frac{1}{\pi_a^{(k-1)}} + \Omega_a^{(k)}}
+
+    where :math:`\Omega_a^{(k)}` is the *total predicted volatility*. This term is the
+    sum of the tonic (endogenous) and phasic (exogenous) volatility, such as:
+
+    .. math::
+
+        \Omega_a^{(k)} = t^{(k)}
+        \exp{ \left( \omega_a + \sum_{j=1}^{N_{vopa}} \kappa_j \hat{\mu}_a^{(k-1)} \right) }
+
+
+    with :math:`\kappa_j` the volatility coupling strength with the volatility parent
+    :math:`j`.
+
+    The *effective precision* :math:`\gamma_a^{(k)}` is given by:
+
+    .. math::
+
+        \gamma_a^{(k)} = \Omega_a^{(k)} \hat{\pi}_a^{(k)}
+
+    This value is also saved in the node for later use during the update steps.
+
+
+    Parameters
+    ----------
+    attributes :
+        The attributes of the probabilistic network that contains the continuous state
+        node.
+    edges :
+        The edges of the probabilistic network as a tuple of
+        :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as the number of
+        nodes. For each node, the index list value/volatility - parents/children.
+    node_idx :
+        Index of the node that should be updated.
+
+    Returns
+    -------
+    expected_precision :
+        The new expected precision of the value parent.
+    effective_precision :
+        The effective_precision :math:`\gamma_a^{(k)}`. This value is stored in the
+        node for later use in the update steps.
+
+    References
+    ----------
+    .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
+       Mathys, C. (2023). The generalized Hierarchical Gaussian Filter (Version 1).
+       arXiv. https://doi.org/10.48550/ARXIV.2305.10937
+
+    """
+    time_step = attributes[-1]["time_step"]
+
+    volatility_parents_idxs = edges[node_idx].volatility_parents
+    total_volatility = attributes[node_idx]["tonic_volatility"]
+
+    if volatility_parents_idxs is not None:
+        for volatility_parents_idx, volatility_coupling in zip(
+            volatility_parents_idxs,
+            attributes[node_idx]["volatility_coupling_parents"],
+        ):
+            total_volatility += (
+                volatility_coupling
+                * attributes[volatility_parents_idx]["expected_mean"]
+            )
+
+    predicted_volatility = time_step * jnp.exp(total_volatility)
+    predicted_volatility = jnp.where(
+        predicted_volatility > 1e-128, predicted_volatility, jnp.nan
+    )
+
+    expected_precision = 1 / (
+        (1 / attributes[node_idx]["precision"]) + predicted_volatility
+    )
+    effective_precision = predicted_volatility * expected_precision
+
+    return expected_precision, expected_precision, effective_precision
+
+
+@partial(jit, static_argnames=("edges", "node_idx"))
+def continuous_node_prediction_mean_field(
+    attributes: dict, node_idx: int, edges: Edges, **args
+) -> dict:
+    """Mean-field (v0.2.11) prediction step for a continuous node.
+
+    Uses the simple v0.2.11 formula: no MGF correction on volatility total, no Laplace
+    value-coupling variance term.
+    """
+    attributes[node_idx]["temp"]["current_variance"] = (
+        1 / attributes[node_idx]["precision"]
+    )
+
+    expected_mean = predict_mean(attributes, edges, node_idx)
+
+    expected_precision, conditional_expected_precision, effective_precision = (
+        predict_precision_mean_field(attributes, edges, node_idx)
+    )
+
+    if (
+        (edges[node_idx].value_children is None)
+        and (edges[node_idx].volatility_children is None)
+        and (edges[node_idx].volatility_parents is None)
+    ):
+        attributes[node_idx]["expected_precision"] = attributes[node_idx]["precision"]
+        attributes[node_idx]["temp"]["conditional_expected_precision"] = attributes[
+            node_idx
+        ]["precision"]
     else:
         attributes[node_idx]["expected_precision"] = expected_precision
         attributes[node_idx]["temp"]["conditional_expected_precision"] = (

--- a/pyhgf/updates/prediction/volatile.py
+++ b/pyhgf/updates/prediction/volatile.py
@@ -266,3 +266,90 @@ def volatile_node_prediction(
         attributes[node_idx]["temp"]["effective_precision"] = effective_precision
 
     return attributes
+
+
+@partial(jit, static_argnames=("edges", "node_idx"))
+def predict_precision_value_level_mean_field(
+    attributes: dict,
+    edges: Edges,
+    node_idx: int,
+) -> tuple[Array, Array, Array]:
+    """Predict the precision of the value level using the implicit volatility level.
+
+    The volatility level's mean modulates the value level's precision.
+    """
+    time_step = attributes[-1]["time_step"]
+
+    precision = attributes[node_idx]["precision"]
+    tonic_volatility = attributes[node_idx]["tonic_volatility"]
+    expected_mean_vol = attributes[node_idx]["expected_mean_vol"]
+    volatility_coupling_internal = attributes[node_idx]["volatility_coupling_internal"]
+
+    total_volatility = tonic_volatility + (
+        volatility_coupling_internal * expected_mean_vol
+    )
+
+    predicted_volatility = time_step * jnp.exp(total_volatility)
+    predicted_volatility = jnp.where(
+        predicted_volatility > 1e-128, predicted_volatility, jnp.nan
+    )
+
+    expected_precision = 1 / ((1 / precision) + predicted_volatility)
+    effective_precision = predicted_volatility * expected_precision
+
+    return expected_precision, expected_precision, effective_precision
+
+
+@partial(jit, static_argnames=("edges", "node_idx"))
+def volatile_node_prediction_mean_field(
+    attributes: dict, node_idx: int, edges: Edges, **args
+) -> dict:
+    """Update the expected mean and expected precision of a value-volatility node.
+
+    This node has two internal levels:
+    1. Volatility level (implicit, internal)
+    2. Value level (external facing)
+
+    The volatility level predicts first, then affects the value level's precision.
+    """
+    attributes[node_idx]["temp"]["current_variance"] = (
+        1 / attributes[node_idx]["precision"]
+    )
+
+    # Volatility level prediction (unchanged — no relaxed changes here)
+    expected_precision_vol, effective_precision_vol = (
+        predict_precision_volatility_level(attributes, node_idx)
+    )
+
+    attributes[node_idx]["expected_mean_vol"] = attributes[node_idx]["mean_vol"]
+    attributes[node_idx]["expected_precision_vol"] = expected_precision_vol
+    attributes[node_idx]["temp"]["effective_precision_vol"] = effective_precision_vol
+
+    # Value level precision — mean_field: no MGF, no Laplace correction
+    expected_precision, conditional_expected_precision, effective_precision = (
+        predict_precision_value_level_mean_field(attributes, edges, node_idx)
+    )
+
+    expected_mean = predict_mean_value_level(attributes, edges, node_idx)
+    attributes[node_idx]["expected_mean"] = expected_mean
+
+    if (
+        (edges[node_idx].value_children is None)
+        and (edges[node_idx].volatility_children is None)
+        and (edges[node_idx].volatility_parents is None)
+    ):
+        attributes[node_idx]["expected_precision"] = attributes[node_idx]["precision"]
+        attributes[node_idx]["temp"]["conditional_expected_precision"] = attributes[
+            node_idx
+        ]["precision"]
+        attributes[node_idx]["temp"]["effective_precision"] = jnp.zeros_like(
+            effective_precision
+        )
+    else:
+        attributes[node_idx]["expected_precision"] = expected_precision
+        attributes[node_idx]["temp"]["conditional_expected_precision"] = (
+            conditional_expected_precision
+        )
+        attributes[node_idx]["temp"]["effective_precision"] = effective_precision
+
+    return attributes

--- a/pyhgf/updates/prediction_error/binary.py
+++ b/pyhgf/updates/prediction_error/binary.py
@@ -76,8 +76,8 @@ def binary_finite_state_node_prediction_error(
     References
     ----------
     .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
-       Mathys, C. (2023). The generalized Hierarchical Gaussian Filter (Version 1).
-       arXiv. https://doi.org/10.48550/ARXIV.2305.10937
+       Mathys, C. (2026). The generalized hierarchical Gaussian filter.
+       doi:10.7554/elife.110174.1
     """
     value_child_idx = edges[node_idx].value_children[0]  # type: ignore
 

--- a/pyhgf/updates/prediction_error/continuous.py
+++ b/pyhgf/updates/prediction_error/continuous.py
@@ -45,8 +45,8 @@ def continuous_node_value_prediction_error(
     References
     ----------
     .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
-       Mathys, C. (2023). The generalized Hierarchical Gaussian Filter (Version 1).
-       arXiv. https://doi.org/10.48550/ARXIV.2305.10937
+       Mathys, C. (2026). The generalized hierarchical Gaussian filter.
+       doi:10.7554/elife.110174.1
 
     """
     # value prediction error
@@ -95,8 +95,8 @@ def continuous_node_volatility_prediction_error(
     References
     ----------
     .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
-       Mathys, C. (2023). The generalized Hierarchical Gaussian Filter (Version 1).
-       arXiv. https://doi.org/10.48550/ARXIV.2305.10937
+       Mathys, C. (2026). The generalized hierarchical Gaussian filter.
+       doi:10.7554/elife.110174.1
 
     """
     # compute the volatility prediction error (VOPE)
@@ -157,8 +157,8 @@ def continuous_node_prediction_error(
     References
     ----------
     .. [1] Weber, L. A., Waade, P. T., Legrand, N., Møller, A. H., Stephan, K. E., &
-       Mathys, C. (2023). The generalized Hierarchical Gaussian Filter (Version 1).
-       arXiv. https://doi.org/10.48550/ARXIV.2305.10937
+       Mathys, C. (2026). The generalized hierarchical Gaussian filter.
+       doi:10.7554/elife.110174.1
     """
     # Store value prediction errors
     # -----------------------------

--- a/pyhgf/utils/get_update_sequence.py
+++ b/pyhgf/utils/get_update_sequence.py
@@ -9,6 +9,8 @@ from pyhgf.updates.posterior.categorical import categorical_state_update
 from pyhgf.updates.posterior.continuous import (
     continuous_node_posterior_update,
     continuous_node_posterior_update_ehgf,
+    continuous_node_posterior_update_ehgf_mean_field,
+    continuous_node_posterior_update_mean_field,
     continuous_node_posterior_update_unbounded,
 )
 from pyhgf.updates.posterior.exponential import (
@@ -16,11 +18,18 @@ from pyhgf.updates.posterior.exponential import (
 )
 from pyhgf.updates.posterior.volatile import (
     volatile_node_posterior_update,
+    volatile_node_posterior_update_mean_field,
 )
 from pyhgf.updates.prediction.binary import binary_state_node_prediction
-from pyhgf.updates.prediction.continuous import continuous_node_prediction
+from pyhgf.updates.prediction.continuous import (
+    continuous_node_prediction,
+    continuous_node_prediction_mean_field,
+)
 from pyhgf.updates.prediction.dirichlet import dirichlet_node_prediction
-from pyhgf.updates.prediction.volatile import volatile_node_prediction
+from pyhgf.updates.prediction.volatile import (
+    volatile_node_prediction,
+    volatile_node_prediction_mean_field,
+)
 from pyhgf.updates.prediction_error.binary import binary_state_node_prediction_error
 from pyhgf.updates.prediction_error.categorical import (
     categorical_state_prediction_error,
@@ -39,7 +48,9 @@ if TYPE_CHECKING:
     from pyhgf.model import Network
 
 
-def get_update_sequence(network: "Network", update_type: str) -> UpdateSequence:
+def get_update_sequence(
+    network: "Network", update_type: str, mean_field_updates: bool = False
+) -> UpdateSequence:
     """Generate an update sequence from the network's structure.
 
     This function return an optimized update sequence considering the edges of the
@@ -115,11 +126,21 @@ def get_update_sequence(network: "Network", update_type: str) -> UpdateSequence:
                 if network.edges[idx].node_type == 1:
                     prediction_sequence.append((idx, binary_state_node_prediction))
                 elif network.edges[idx].node_type == 2:
-                    prediction_sequence.append((idx, continuous_node_prediction))
+                    prediction_sequence.append((
+                        idx,
+                        continuous_node_prediction_mean_field
+                        if mean_field_updates
+                        else continuous_node_prediction,
+                    ))
                 elif network.edges[idx].node_type == 4:
                     prediction_sequence.append((idx, dirichlet_node_prediction))
                 elif network.edges[idx].node_type == 6:
-                    prediction_sequence.append((idx, volatile_node_prediction))
+                    prediction_sequence.append((
+                        idx,
+                        volatile_node_prediction_mean_field
+                        if mean_field_updates
+                        else volatile_node_prediction,
+                    ))
 
         if not nodes_without_prediction:
             break
@@ -153,18 +174,38 @@ def get_update_sequence(network: "Network", update_type: str) -> UpdateSequence:
             if all([i not in nodes_without_prediction_error for i in all_children]):
                 no_update = False
                 if network.edges[idx].node_type == 2:
+                    has_vol_children = (
+                        network.edges[idx].volatility_children is not None
+                    )
                     if update_type == "unbounded":
-                        if network.edges[idx].volatility_children is not None:
-                            update_fn = continuous_node_posterior_update_unbounded
-                        else:
-                            update_fn = continuous_node_posterior_update
+                        update_fn = (
+                            continuous_node_posterior_update_unbounded
+                            if has_vol_children
+                            else (
+                                continuous_node_posterior_update_mean_field
+                                if mean_field_updates
+                                else continuous_node_posterior_update
+                            )
+                        )
                     elif update_type == "eHGF":
-                        if network.edges[idx].volatility_children is not None:
-                            update_fn = continuous_node_posterior_update_ehgf
+                        if has_vol_children:
+                            update_fn = (
+                                continuous_node_posterior_update_ehgf_mean_field
+                                if mean_field_updates
+                                else continuous_node_posterior_update_ehgf
+                            )
                         else:
-                            update_fn = continuous_node_posterior_update
+                            update_fn = (
+                                continuous_node_posterior_update_mean_field
+                                if mean_field_updates
+                                else continuous_node_posterior_update
+                            )
                     elif update_type == "standard":
-                        update_fn = continuous_node_posterior_update
+                        update_fn = (
+                            continuous_node_posterior_update_mean_field
+                            if mean_field_updates
+                            else continuous_node_posterior_update
+                        )
                     else:
                         raise ValueError("Invalid update type.")
                     update_fn = Partial(
@@ -174,7 +215,9 @@ def get_update_sequence(network: "Network", update_type: str) -> UpdateSequence:
 
                 elif network.edges[idx].node_type == 6:
                     update_fn = Partial(
-                        volatile_node_posterior_update,
+                        volatile_node_posterior_update_mean_field
+                        if mean_field_updates
+                        else volatile_node_posterior_update,
                         max_posterior_precision=network.max_posterior_precision,
                     )
 

--- a/pyhgf/utils/vectorized_belief_propagation.py
+++ b/pyhgf/utils/vectorized_belief_propagation.py
@@ -467,7 +467,7 @@ def propagation_step(
     elements = list(network.layers)
     n_elements = len(elements)
     max_posterior_precision = network.max_posterior_precision
-    update_type = network.update_type
+    update_type = network.volatility_updates
 
     # 1. Set predictors on the top element.
     elements[-1] = _set_top_predictors(elements[-1], x)

--- a/src/model.rs
+++ b/src/model.rs
@@ -298,7 +298,7 @@ pub struct Network{
     pub attributes: Attributes,
     pub edges: Vec<AdjacencyLists>,
     pub inputs: Vec<usize>,
-    pub update_type: String,
+    pub volatility_updates: String,
     pub update_sequence: UpdateSequence,
     pub node_trajectories: NodeTrajectories,
     pub layers: Vec<Vec<usize>>,
@@ -377,12 +377,12 @@ fn trajectory_field_ref<'a>(traj: &'a NodeTrajectory, field: &str) -> &'a Vec<f6
 // Core Rust methods (also callable from Python via chaining wrappers below)
 impl Network {
 
-    pub fn new(update_type: &str) -> Self {
+    pub fn new(volatility_updates: &str) -> Self {
         Network {
             attributes: Attributes { states: Vec::new(), vectors: Vec::new(), fn_ptrs: Vec::new() },
             edges: Vec::new(),
             inputs: Vec::new(),
-            update_type: String::from(update_type),
+            volatility_updates: String::from(volatility_updates),
             update_sequence: UpdateSequence { predictions: Vec::new(), updates: Vec::new() },
             node_trajectories: NodeTrajectories { nodes: Vec::new() },
             layers: Vec::new(),
@@ -1033,7 +1033,7 @@ impl Network {
             attributes: self.attributes.clone(),
             edges: self.edges.clone(),
             inputs: Vec::new(),
-            update_type: String::new(),
+            volatility_updates: String::new(),
             update_sequence: UpdateSequence {
                 predictions: Vec::new(),
                 updates: Vec::new(),
@@ -1204,9 +1204,9 @@ fn apply_overrides_volatile(state: &mut NodeState, overrides: &HashMap<String, f
 impl Network {
 
     #[new]
-    #[pyo3(signature = (update_type="unbounded", max_posterior_precision=1e10))]
-    fn py_new(update_type: &str, max_posterior_precision: f64) -> Self {
-        let mut net = Network::new(update_type);
+    #[pyo3(signature = (volatility_updates="unbounded", max_posterior_precision=1e10))]
+    fn py_new(volatility_updates: &str, max_posterior_precision: f64) -> Self {
+        let mut net = Network::new(volatility_updates);
         net.max_posterior_precision = max_posterior_precision;
         net
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -299,6 +299,7 @@ pub struct Network{
     pub edges: Vec<AdjacencyLists>,
     pub inputs: Vec<usize>,
     pub volatility_updates: String,
+    pub mean_field_updates: bool,
     pub update_sequence: UpdateSequence,
     pub node_trajectories: NodeTrajectories,
     pub layers: Vec<Vec<usize>>,
@@ -383,6 +384,7 @@ impl Network {
             edges: Vec::new(),
             inputs: Vec::new(),
             volatility_updates: String::from(volatility_updates),
+            mean_field_updates: false,
             update_sequence: UpdateSequence { predictions: Vec::new(), updates: Vec::new() },
             node_trajectories: NodeTrajectories { nodes: Vec::new() },
             layers: Vec::new(),
@@ -1034,6 +1036,7 @@ impl Network {
             edges: self.edges.clone(),
             inputs: Vec::new(),
             volatility_updates: String::new(),
+            mean_field_updates: false,
             update_sequence: UpdateSequence {
                 predictions: Vec::new(),
                 updates: Vec::new(),
@@ -1204,10 +1207,11 @@ fn apply_overrides_volatile(state: &mut NodeState, overrides: &HashMap<String, f
 impl Network {
 
     #[new]
-    #[pyo3(signature = (volatility_updates="unbounded", max_posterior_precision=1e10))]
-    fn py_new(volatility_updates: &str, max_posterior_precision: f64) -> Self {
+    #[pyo3(signature = (volatility_updates="unbounded", max_posterior_precision=1e10, mean_field_updates=false))]
+    fn py_new(volatility_updates: &str, max_posterior_precision: f64, mean_field_updates: bool) -> Self {
         let mut net = Network::new(volatility_updates);
         net.max_posterior_precision = max_posterior_precision;
+        net.mean_field_updates = mean_field_updates;
         net
     }
 

--- a/src/updates/posterior/continuous.rs
+++ b/src/updates/posterior/continuous.rs
@@ -326,3 +326,162 @@ pub fn posterior_update_continuous_state_node_unbounded(network: &mut Network, n
     state.precision = posterior_precision;
     state.mean = posterior_mean;
 }
+
+// =============================================================================
+// Mean-field (v0.2.11) building blocks
+// =============================================================================
+
+/// Mean-field precision update from children.
+///
+/// Uses `expected_precision` directly as the child-precision factor.
+fn precision_update_from_children_mean_field(network: &Network, node_idx: usize) -> f64 {
+    let mut precision_wpe = 0.0;
+
+    if let Some(ref vc_idxs) = network.edges[node_idx].value_children {
+        let coupling_strengths = &network.attributes.vectors[node_idx].value_coupling_children;
+        let parent_mean = network.attributes.states[node_idx].mean;
+        let coupling_fn = network.attributes.fn_ptrs[node_idx].coupling_fn;
+
+        for (i, &child_idx) in vc_idxs.iter().enumerate() {
+            let child_state = &network.attributes.states[child_idx];
+            let child_expected_precision = child_state.expected_precision;
+            let observed = child_state.observed;
+            let kappa = coupling_strengths.get(i).copied().unwrap_or(1.0);
+
+            let (coupling_fn_prime_sq, coupling_fn_second_term) = match coupling_fn {
+                Some(cf) => {
+                    let g_prime = (cf.df)(parent_mean);
+                    let g_second = (cf.d2f)(parent_mean);
+                    let child_vape = child_state.value_prediction_error;
+                    (g_prime.powi(2), kappa * g_second * child_vape)
+                }
+                None => (1.0, 0.0),
+            };
+
+            precision_wpe += (child_expected_precision
+                * (kappa.powi(2) * coupling_fn_prime_sq - coupling_fn_second_term))
+                * observed;
+        }
+    }
+
+    if let Some(ref volc_idxs) = network.edges[node_idx].volatility_children {
+        let vol_coupling_strengths =
+            &network.attributes.vectors[node_idx].volatility_coupling_children;
+
+        for (i, &child_idx) in volc_idxs.iter().enumerate() {
+            let child_state = &network.attributes.states[child_idx];
+            let effective_precision = child_state.effective_precision;
+            let volatility_pe = child_state.volatility_prediction_error;
+            let observed = child_state.observed;
+            let kappa = vol_coupling_strengths.get(i).copied().unwrap_or(1.0);
+
+            precision_wpe += (0.5 * (kappa * effective_precision).powi(2)
+                + (kappa * effective_precision).powi(2) * volatility_pe
+                - 0.5 * kappa.powi(2) * effective_precision * volatility_pe)
+                * observed;
+        }
+    }
+
+    precision_wpe
+}
+
+/// Mean-field mean update from children.
+///
+/// Uses `expected_precision` directly as the value-coupling gain.
+fn mean_update_from_children_mean_field(
+    network: &Network,
+    node_idx: usize,
+    node_precision: f64,
+) -> f64 {
+    let mut value_pwpe = 0.0;
+    let mut volatility_pwpe = 0.0;
+
+    if let Some(ref vc_idxs) = network.edges[node_idx].value_children {
+        let coupling_strengths = &network.attributes.vectors[node_idx].value_coupling_children;
+        let parent_mean = network.attributes.states[node_idx].mean;
+        let coupling_fn = network.attributes.fn_ptrs[node_idx].coupling_fn;
+
+        for (i, &child_idx) in vc_idxs.iter().enumerate() {
+            let child_state = &network.attributes.states[child_idx];
+            let child_expected_precision = child_state.expected_precision;
+            let child_vape = child_state.value_prediction_error * child_state.observed;
+            let kappa = coupling_strengths.get(i).copied().unwrap_or(1.0);
+
+            let coupling_fn_prime = match coupling_fn {
+                Some(cf) => (cf.df)(parent_mean),
+                None => 1.0,
+            };
+
+            value_pwpe +=
+                (kappa * coupling_fn_prime * child_expected_precision / node_precision)
+                    * child_vape;
+        }
+    }
+
+    if let Some(ref volc_idxs) = network.edges[node_idx].volatility_children {
+        let vol_coupling_strengths =
+            &network.attributes.vectors[node_idx].volatility_coupling_children;
+
+        for (i, &child_idx) in volc_idxs.iter().enumerate() {
+            let child_state = &network.attributes.states[child_idx];
+            let effective_precision = child_state.effective_precision;
+            let volatility_pe = child_state.volatility_prediction_error;
+            let observed = child_state.observed;
+            let kappa = vol_coupling_strengths.get(i).copied().unwrap_or(1.0);
+
+            volatility_pwpe +=
+                (kappa * effective_precision * volatility_pe) / (2.0 * node_precision)
+                    * observed;
+        }
+    }
+
+    value_pwpe + volatility_pwpe
+}
+
+// =============================================================================
+// Mean-field posterior updates
+// =============================================================================
+
+pub fn posterior_update_continuous_state_node_mean_field(
+    network: &mut Network,
+    node_idx: usize,
+    _time_step: f64,
+) {
+    let expected_precision = network.attributes.states[node_idx].expected_precision;
+    let expected_mean = network.attributes.states[node_idx].expected_mean;
+    let max_posterior_precision = network.max_posterior_precision;
+
+    let precision_wpe = precision_update_from_children_mean_field(network, node_idx);
+    let posterior_precision = (expected_precision + precision_wpe)
+        .max(1e-128)
+        .min(max_posterior_precision);
+
+    let mean_wpe =
+        mean_update_from_children_mean_field(network, node_idx, posterior_precision);
+    let posterior_mean = expected_mean + mean_wpe;
+
+    let state = &mut network.attributes.states[node_idx];
+    state.precision = posterior_precision;
+    state.mean = posterior_mean;
+}
+
+pub fn posterior_update_continuous_state_node_ehgf_mean_field(
+    network: &mut Network,
+    node_idx: usize,
+    _time_step: f64,
+) {
+    let expected_precision = network.attributes.states[node_idx].expected_precision;
+    let expected_mean = network.attributes.states[node_idx].expected_mean;
+    let max_posterior_precision = network.max_posterior_precision;
+
+    let mean_wpe =
+        mean_update_from_children_mean_field(network, node_idx, expected_precision);
+    let posterior_mean = expected_mean + mean_wpe;
+    network.attributes.states[node_idx].mean = posterior_mean;
+
+    let precision_wpe = precision_update_from_children_mean_field(network, node_idx);
+    let posterior_precision = (expected_precision + precision_wpe)
+        .max(1e-128)
+        .min(max_posterior_precision);
+    network.attributes.states[node_idx].precision = posterior_precision;
+}

--- a/src/updates/posterior/volatile.rs
+++ b/src/updates/posterior/volatile.rs
@@ -147,3 +147,88 @@ pub fn posterior_update_volatile_state_node(network: &mut Network, node_idx: usi
     let mean_value = mean_update_value_level(network, node_idx, precision_value);
     network.attributes.states[node_idx].mean = mean_value;
 }
+
+// =============================================================================
+// Mean-field value-level building blocks
+// =============================================================================
+
+fn precision_update_value_level_mean_field(network: &Network, node_idx: usize) -> f64 {
+    let expected_precision = network.attributes.states[node_idx].expected_precision;
+    let mut posterior_precision = expected_precision;
+
+    if let Some(ref vc_idxs) = network.edges[node_idx].value_children {
+        let coupling_strengths = &network.attributes.vectors[node_idx].value_coupling_children;
+        let parent_expected_mean = network.attributes.states[node_idx].expected_mean;
+        let coupling_fn = network.attributes.fn_ptrs[node_idx].coupling_fn;
+
+        for (i, &child_idx) in vc_idxs.iter().enumerate() {
+            let child_state = &network.attributes.states[child_idx];
+            let child_expected_precision = child_state.expected_precision;
+            let kappa = coupling_strengths.get(i).copied().unwrap_or(1.0);
+
+            let (coupling_fn_prime_sq, coupling_fn_second_term) = match coupling_fn {
+                Some(cf) => {
+                    let g_prime = (cf.df)(parent_expected_mean);
+                    let g_second = (cf.d2f)(parent_expected_mean);
+                    let child_vape = child_state.value_prediction_error;
+                    (g_prime.powi(2), kappa * g_second * child_vape)
+                }
+                None => (1.0, 0.0),
+            };
+
+            posterior_precision += child_expected_precision
+                * (kappa.powi(2) * coupling_fn_prime_sq - coupling_fn_second_term);
+        }
+    }
+
+    posterior_precision
+}
+
+fn mean_update_value_level_mean_field(
+    network: &Network,
+    node_idx: usize,
+    node_precision: f64,
+) -> f64 {
+    let expected_mean = network.attributes.states[node_idx].expected_mean;
+    let mut value_pwpe = 0.0;
+
+    if let Some(ref vc_idxs) = network.edges[node_idx].value_children {
+        let coupling_strengths = &network.attributes.vectors[node_idx].value_coupling_children;
+        let parent_expected_mean = network.attributes.states[node_idx].expected_mean;
+        let coupling_fn = network.attributes.fn_ptrs[node_idx].coupling_fn;
+
+        for (i, &child_idx) in vc_idxs.iter().enumerate() {
+            let child_state = &network.attributes.states[child_idx];
+            let child_expected_precision = child_state.expected_precision;
+            let kappa = coupling_strengths.get(i).copied().unwrap_or(1.0);
+
+            let coupling_fn_prime = match coupling_fn {
+                Some(cf) => (cf.df)(parent_expected_mean),
+                None => 1.0,
+            };
+
+            value_pwpe += (kappa * coupling_fn_prime * child_expected_precision
+                / node_precision)
+                * child_state.value_prediction_error;
+        }
+    }
+
+    expected_mean + value_pwpe
+}
+
+// =============================================================================
+// Mean-field volatile posterior update
+// =============================================================================
+
+pub fn posterior_update_volatile_state_node_mean_field(
+    network: &mut Network,
+    node_idx: usize,
+    _time_step: f64,
+) {
+    let precision_value = precision_update_value_level_mean_field(network, node_idx)
+        .min(network.max_posterior_precision);
+    network.attributes.states[node_idx].precision = precision_value;
+
+    let mean_value = mean_update_value_level_mean_field(network, node_idx, precision_value);
+    network.attributes.states[node_idx].mean = mean_value;
+}

--- a/src/updates/prediction/continuous.rs
+++ b/src/updates/prediction/continuous.rs
@@ -112,3 +112,64 @@ pub fn prediction_continuous_state_node(network: &mut Network, node_idx: usize, 
         state.conditional_expected_precision = precision;
     }
 }
+
+/// Mean-field prediction step for a continuous state node.
+pub fn prediction_continuous_state_node_mean_field(
+    network: &mut Network,
+    node_idx: usize,
+    time_step: f64,
+) {
+    let mean = network.attributes.states[node_idx].mean;
+    let tonic_drift = network.attributes.states[node_idx].tonic_drift;
+    let autoconnection_strength = network.attributes.states[node_idx].autoconnection_strength;
+    let precision = network.attributes.states[node_idx].precision;
+    let tonic_volatility = network.attributes.states[node_idx].tonic_volatility;
+
+    let mut driftrate = tonic_drift;
+
+    if let Some(ref vp_idxs) = network.edges[node_idx].value_parents {
+        let couplings = &network.attributes.vectors[node_idx].value_coupling_parents;
+        for (i, &parent_idx) in vp_idxs.iter().enumerate() {
+            let parent_expected_mean = network.attributes.states[parent_idx].expected_mean;
+            let psi = couplings.get(i).copied().unwrap_or(1.0);
+            let parent_value = match network.attributes.fn_ptrs[parent_idx].coupling_fn {
+                Some(cf) => (cf.f)(parent_expected_mean),
+                None => parent_expected_mean,
+            };
+            driftrate += psi * parent_value;
+        }
+    }
+
+    let expected_mean = autoconnection_strength * mean + time_step * driftrate;
+
+    let mut total_volatility = tonic_volatility;
+    if let Some(ref vol_parent_idxs) = network.edges[node_idx].volatility_parents {
+        let vol_couplings = &network.attributes.vectors[node_idx].volatility_coupling_parents;
+        for (i, &parent_idx) in vol_parent_idxs.iter().enumerate() {
+            let parent_mean = network.attributes.states[parent_idx].mean;
+            let kappa = vol_couplings.get(i).copied().unwrap_or(1.0);
+            total_volatility += kappa * parent_mean;
+        }
+    }
+
+    let pv_raw = time_step * total_volatility.exp();
+    let predicted_volatility = if pv_raw > 1e-128 { pv_raw } else { f64::NAN };
+    let expected_precision = 1.0 / ((1.0 / precision) + predicted_volatility);
+    let effective_precision = predicted_volatility * expected_precision;
+
+    let is_input = network.edges[node_idx].value_children.is_none()
+        && network.edges[node_idx].volatility_children.is_none();
+    let has_volatility_parents = network.edges[node_idx].volatility_parents.is_some();
+
+    let state = &mut network.attributes.states[node_idx];
+    state.current_variance = 1.0 / precision;
+    state.expected_mean = expected_mean;
+    state.effective_precision = effective_precision;
+
+    if !(is_input && !has_volatility_parents) {
+        state.expected_precision = expected_precision;
+        state.conditional_expected_precision = expected_precision;
+    } else {
+        state.conditional_expected_precision = precision;
+    }
+}

--- a/src/updates/prediction/volatile.rs
+++ b/src/updates/prediction/volatile.rs
@@ -120,3 +120,69 @@ pub fn prediction_volatile_state_node(network: &mut Network, node_idx: usize, ti
         state.effective_precision = effective_precision;
     }
 }
+
+/// Mean-field prediction step for a volatile state node.
+pub fn prediction_volatile_state_node_mean_field(
+    network: &mut Network,
+    node_idx: usize,
+    time_step: f64,
+) {
+    let precision = network.attributes.states[node_idx].precision;
+    let mean = network.attributes.states[node_idx].mean;
+    let autoconnection_strength = network.attributes.states[node_idx].autoconnection_strength;
+    let tonic_volatility = network.attributes.states[node_idx].tonic_volatility;
+    let mean_vol = network.attributes.states[node_idx].mean_vol;
+    let precision_vol = network.attributes.states[node_idx].precision_vol;
+    let tonic_volatility_vol = network.attributes.states[node_idx].tonic_volatility_vol;
+    let volatility_coupling_internal =
+        network.attributes.states[node_idx].volatility_coupling_internal;
+
+    let current_variance = 1.0 / precision;
+
+    // Volatility level (unchanged)
+    let pvv_raw = time_step * tonic_volatility_vol.exp();
+    let predicted_volatility_vol = if pvv_raw > 1e-128 { pvv_raw } else { f64::NAN };
+    let expected_precision_vol = 1.0 / ((1.0 / precision_vol) + predicted_volatility_vol);
+    let effective_precision_vol = predicted_volatility_vol * expected_precision_vol;
+
+    // Value level mean (no change)
+    let mut driftrate = 0.0;
+    if let Some(ref vp_idxs) = network.edges[node_idx].value_parents {
+        let couplings = &network.attributes.vectors[node_idx].value_coupling_parents;
+        for (i, &parent_idx) in vp_idxs.iter().enumerate() {
+            let parent_expected_mean = network.attributes.states[parent_idx].expected_mean;
+            let psi = couplings.get(i).copied().unwrap_or(1.0);
+            let parent_value = match network.attributes.fn_ptrs[parent_idx].coupling_fn {
+                Some(cf) => (cf.f)(parent_expected_mean),
+                None => parent_expected_mean,
+            };
+            driftrate += psi * parent_value;
+        }
+    }
+    let expected_mean = autoconnection_strength * mean + time_step * driftrate;
+
+    // Value level precision — no MGF, no Laplace correction
+    let total_volatility = tonic_volatility + volatility_coupling_internal * mean_vol;
+    let pv_raw = time_step * total_volatility.exp();
+    let predicted_volatility = if pv_raw > 1e-128 { pv_raw } else { f64::NAN };
+    let expected_precision = 1.0 / ((1.0 / precision) + predicted_volatility);
+    let effective_precision = predicted_volatility * expected_precision;
+
+    let is_input = network.edges[node_idx].value_children.is_none();
+
+    let state = &mut network.attributes.states[node_idx];
+    state.current_variance = current_variance;
+    state.expected_mean_vol = mean_vol;
+    state.expected_precision_vol = expected_precision_vol;
+    state.effective_precision_vol = effective_precision_vol;
+    state.expected_mean = expected_mean;
+    if is_input {
+        state.expected_precision = precision;
+        state.conditional_expected_precision = precision;
+        state.effective_precision = 0.0;
+    } else {
+        state.expected_precision = expected_precision;
+        state.conditional_expected_precision = expected_precision;
+        state.effective_precision = effective_precision;
+    }
+}

--- a/src/utils/function_pointer.rs
+++ b/src/utils/function_pointer.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{model::Network, updates::{posterior::continuous::{posterior_update_continuous_state_node, posterior_update_continuous_state_node_ehgf, posterior_update_continuous_state_node_unbounded}, posterior::volatile::posterior_update_volatile_state_node, prediction::binary::prediction_binary_state_node, prediction::continuous::prediction_continuous_state_node, prediction::volatile::prediction_volatile_state_node, prediction_error::{binary::prediction_error_binary_state_node, continuous::prediction_error_continuous_state_node, exponential::prediction_error_exponential_state_node, volatile::{prediction_error_volatile_state_node, prediction_error_volatile_state_node_ehgf, prediction_error_volatile_state_node_unbounded}}}};
+use crate::{model::Network, updates::{posterior::continuous::{posterior_update_continuous_state_node, posterior_update_continuous_state_node_ehgf, posterior_update_continuous_state_node_unbounded, posterior_update_continuous_state_node_mean_field, posterior_update_continuous_state_node_ehgf_mean_field}, posterior::volatile::{posterior_update_volatile_state_node, posterior_update_volatile_state_node_mean_field}, prediction::binary::prediction_binary_state_node, prediction::continuous::{prediction_continuous_state_node, prediction_continuous_state_node_mean_field}, prediction::volatile::{prediction_volatile_state_node, prediction_volatile_state_node_mean_field}, prediction_error::{binary::prediction_error_binary_state_node, continuous::prediction_error_continuous_state_node, exponential::prediction_error_exponential_state_node, volatile::{prediction_error_volatile_state_node, prediction_error_volatile_state_node_ehgf, prediction_error_volatile_state_node_unbounded}}}};
 use crate::updates::learning::learning_weights;
 
 // Create a default signature for update functions
@@ -12,12 +12,17 @@ pub type FnType = for<'a> fn(&'a mut Network, usize, f64);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpdateStep {
     PredictionContinuous,
+    PredictionContinuousMeanField,
     PredictionVolatile,
+    PredictionVolatileMeanField,
     PredictionBinary,
     PosteriorContinuous,
+    PosteriorContinuousMeanField,
     PosteriorContinuousEhgf,
+    PosteriorContinuousEhgfMeanField,
     PosteriorContinuousUnbounded,
     PosteriorVolatile,
+    PosteriorVolatileMeanField,
     PredictionErrorContinuous,
     PredictionErrorVolatile,
     PredictionErrorVolatileEhgf,
@@ -32,12 +37,17 @@ impl UpdateStep {
     pub fn call(self, network: &mut Network, node_idx: usize, time_step: f64) {
         match self {
             Self::PredictionContinuous => prediction_continuous_state_node(network, node_idx, time_step),
+            Self::PredictionContinuousMeanField => prediction_continuous_state_node_mean_field(network, node_idx, time_step),
             Self::PredictionVolatile => prediction_volatile_state_node(network, node_idx, time_step),
+            Self::PredictionVolatileMeanField => prediction_volatile_state_node_mean_field(network, node_idx, time_step),
             Self::PredictionBinary => prediction_binary_state_node(network, node_idx, time_step),
             Self::PosteriorContinuous => posterior_update_continuous_state_node(network, node_idx, time_step),
+            Self::PosteriorContinuousMeanField => posterior_update_continuous_state_node_mean_field(network, node_idx, time_step),
             Self::PosteriorContinuousEhgf => posterior_update_continuous_state_node_ehgf(network, node_idx, time_step),
+            Self::PosteriorContinuousEhgfMeanField => posterior_update_continuous_state_node_ehgf_mean_field(network, node_idx, time_step),
             Self::PosteriorContinuousUnbounded => posterior_update_continuous_state_node_unbounded(network, node_idx, time_step),
             Self::PosteriorVolatile => posterior_update_volatile_state_node(network, node_idx, time_step),
+            Self::PosteriorVolatileMeanField => posterior_update_volatile_state_node_mean_field(network, node_idx, time_step),
             Self::PredictionErrorContinuous => prediction_error_continuous_state_node(network, node_idx, time_step),
             Self::PredictionErrorVolatile => prediction_error_volatile_state_node(network, node_idx, time_step),
             Self::PredictionErrorVolatileEhgf => prediction_error_volatile_state_node_ehgf(network, node_idx, time_step),
@@ -51,12 +61,17 @@ impl UpdateStep {
     pub fn name(self) -> &'static str {
         match self {
             Self::PredictionContinuous => "prediction_continuous_state_node",
+            Self::PredictionContinuousMeanField => "prediction_continuous_state_node_mean_field",
             Self::PredictionVolatile => "prediction_volatile_state_node",
+            Self::PredictionVolatileMeanField => "prediction_volatile_state_node_mean_field",
             Self::PredictionBinary => "prediction_binary_state_node",
             Self::PosteriorContinuous => "posterior_update_continuous_state_node",
+            Self::PosteriorContinuousMeanField => "posterior_update_continuous_state_node_mean_field",
             Self::PosteriorContinuousEhgf => "posterior_update_continuous_state_node_ehgf",
+            Self::PosteriorContinuousEhgfMeanField => "posterior_update_continuous_state_node_ehgf_mean_field",
             Self::PosteriorContinuousUnbounded => "posterior_update_continuous_state_node_unbounded",
             Self::PosteriorVolatile => "posterior_update_volatile_state_node",
+            Self::PosteriorVolatileMeanField => "posterior_update_volatile_state_node_mean_field",
             Self::PredictionErrorContinuous => "prediction_error_continuous_state_node",
             Self::PredictionErrorVolatile => "prediction_error_volatile_state_node",
             Self::PredictionErrorVolatileEhgf => "prediction_error_volatile_state_node_ehgf",

--- a/src/utils/set_coupling.rs
+++ b/src/utils/set_coupling.rs
@@ -92,7 +92,7 @@ mod tests {
                 },
             ],
             inputs: vec![0],
-            update_type: "standard".into(),
+            volatility_updates: "standard".into(),
             update_sequence: UpdateSequence { predictions: Vec::new(), updates: Vec::new() },
             node_trajectories: NodeTrajectories { nodes: Vec::new() },
             layers: Vec::new(),

--- a/src/utils/set_coupling.rs
+++ b/src/utils/set_coupling.rs
@@ -93,6 +93,7 @@ mod tests {
             ],
             inputs: vec![0],
             volatility_updates: "standard".into(),
+            mean_field_updates: false,
             update_sequence: UpdateSequence { predictions: Vec::new(), updates: Vec::new() },
             node_trajectories: NodeTrajectories { nodes: Vec::new() },
             layers: Vec::new(),

--- a/src/utils/set_sequence.rs
+++ b/src/utils/set_sequence.rs
@@ -34,9 +34,18 @@ pub fn get_predictions_sequence(network: &Network) -> Vec<(usize, UpdateStep)> {
             };
 
             if !contains_common {
+                let mf = network.mean_field_updates;
                 match edge.node_type.as_str() {
-                    "continuous-state" => predictions.push((idx, UpdateStep::PredictionContinuous)),
-                    "volatile-state" => predictions.push((idx, UpdateStep::PredictionVolatile)),
+                    "continuous-state" => predictions.push((
+                        idx,
+                        if mf { UpdateStep::PredictionContinuousMeanField }
+                        else   { UpdateStep::PredictionContinuous },
+                    )),
+                    "volatile-state" => predictions.push((
+                        idx,
+                        if mf { UpdateStep::PredictionVolatileMeanField }
+                        else   { UpdateStep::PredictionVolatile },
+                    )),
                     "binary-state" => predictions.push((idx, UpdateStep::PredictionBinary)),
                     _ => ()
                 }
@@ -77,22 +86,39 @@ pub fn get_updates_sequence(network: &Network) -> Vec<(usize, UpdateStep)> {
             })
             .collect();
 
+        let mf = network.mean_field_updates;
         for &idx in &eligible_po {
             let edge = &network.edges[idx];
             match edge.node_type.as_str() {
                 "continuous-state" => {
                     if edge.volatility_children.is_some() {
                         match network.volatility_updates.as_str() {
-                            "eHGF" => updates.push((idx, UpdateStep::PosteriorContinuousEhgf)),
+                            "eHGF" => updates.push((
+                                idx,
+                                if mf { UpdateStep::PosteriorContinuousEhgfMeanField }
+                                else   { UpdateStep::PosteriorContinuousEhgf },
+                            )),
                             "unbounded" => updates.push((idx, UpdateStep::PosteriorContinuousUnbounded)),
-                            _ => updates.push((idx, UpdateStep::PosteriorContinuous)),
+                            _ => updates.push((
+                                idx,
+                                if mf { UpdateStep::PosteriorContinuousMeanField }
+                                else   { UpdateStep::PosteriorContinuous },
+                            )),
                         }
                     } else {
-                        updates.push((idx, UpdateStep::PosteriorContinuous));
+                        updates.push((
+                            idx,
+                            if mf { UpdateStep::PosteriorContinuousMeanField }
+                            else   { UpdateStep::PosteriorContinuous },
+                        ));
                     }
                 }
                 "volatile-state" => {
-                    updates.push((idx, UpdateStep::PosteriorVolatile));
+                    updates.push((
+                        idx,
+                        if mf { UpdateStep::PosteriorVolatileMeanField }
+                        else   { UpdateStep::PosteriorVolatile },
+                    ));
                 }
                 _ => (),
             }

--- a/src/utils/set_sequence.rs
+++ b/src/utils/set_sequence.rs
@@ -82,7 +82,7 @@ pub fn get_updates_sequence(network: &Network) -> Vec<(usize, UpdateStep)> {
             match edge.node_type.as_str() {
                 "continuous-state" => {
                     if edge.volatility_children.is_some() {
-                        match network.update_type.as_str() {
+                        match network.volatility_updates.as_str() {
                             "eHGF" => updates.push((idx, UpdateStep::PosteriorContinuousEhgf)),
                             "unbounded" => updates.push((idx, UpdateStep::PosteriorContinuousUnbounded)),
                             _ => updates.push((idx, UpdateStep::PosteriorContinuous)),
@@ -117,7 +117,7 @@ pub fn get_updates_sequence(network: &Network) -> Vec<(usize, UpdateStep)> {
                     has_update = true;
                 }
                 ("volatile-state", _) => {
-                    match network.update_type.as_str() {
+                    match network.volatility_updates.as_str() {
                         "eHGF" => updates.push((idx, UpdateStep::PredictionErrorVolatileEhgf)),
                         "unbounded" => updates.push((idx, UpdateStep::PredictionErrorVolatileUnbounded)),
                         _ => updates.push((idx, UpdateStep::PredictionErrorVolatile)),

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -98,7 +98,7 @@ def test_volatile_examples():
     """Test extrem conditions to ensure numerical stability."""
     # repeated identical observations
     hgf = (
-        Network(update_type="unbounded")
+        Network(volatility_updates="unbounded")
         .add_nodes(kind="binary-state")
         .add_nodes(value_children=[0], tonic_volatility=5.0)
     )
@@ -112,7 +112,7 @@ def test_volatile_examples():
 
     # repeated identical observations
     hgf = (
-        Network(update_type="unbounded")
+        Network(volatility_updates="unbounded")
         .add_nodes(kind="binary-state")
         .add_nodes(value_children=[0], tonic_volatility=5.0)
     )

--- a/tests/test_deepnetwork.py
+++ b/tests/test_deepnetwork.py
@@ -285,7 +285,7 @@ def test_three_backends_binary_volatile():
 
         # --- DeepNetwork (JAX vectorized) ---
         dn = (
-            DeepNetwork(update_type=update_type)
+            DeepNetwork(volatility_updates=update_type)
             .add_layer(size=n_targets, kind="binary")
             .add_layer(size=n_targets, add_constant_input=False, fully_connected=False)
             .add_layer(size=n_hidden)
@@ -295,7 +295,7 @@ def test_three_backends_binary_volatile():
 
         # --- RsNetwork (Rust) ---
         rs = (
-            RsNetwork(update_type=update_type)
+            RsNetwork(volatility_updates=update_type)
             .add_nodes(kind="binary-state", n_nodes=n_targets)
             .add_nodes(kind="volatile-state", n_nodes=n_targets, value_children=0)
             .add_layer(size=n_hidden)
@@ -313,7 +313,7 @@ def test_three_backends_binary_volatile():
 
         # --- Network (Python per-node) ---
         net = (
-            PyNetwork(update_type=update_type)
+            PyNetwork(volatility_updates=update_type)
             .add_nodes(kind="binary-state", n_nodes=n_targets)
             .add_nodes(kind="volatile-state", n_nodes=n_targets, value_children=0)
             .add_nodes(kind="volatile-state", n_nodes=n_hidden, value_children=1)

--- a/tests/test_eqx_types.py
+++ b/tests/test_eqx_types.py
@@ -26,7 +26,7 @@ def _make_network_no_weights(layers: tuple) -> Network:
     """Test helper: build a Network with default statics."""
     return Network(
         layers=layers,
-        update_type="eHGF",
+        volatility_updates="eHGF",
         max_posterior_precision=1e10,
     )
 
@@ -139,7 +139,7 @@ def test_network_is_pytree_with_static_meta():
     net = _make_network_no_weights((layer,))
     leaves, treedef = jtu.tree_flatten(net)
     rebuilt = jtu.tree_unflatten(treedef, leaves)
-    assert rebuilt.update_type == "eHGF"
+    assert rebuilt.volatility_updates == "eHGF"
     assert rebuilt.max_posterior_precision == 1e10
     assert rebuilt.n_layers == 1
 
@@ -189,7 +189,7 @@ def test_serialisation_roundtrip(tmp_path):
     eqx.tree_serialise_leaves(str(path), net)
     restored = eqx.tree_deserialise_leaves(str(path), net)
     assert jnp.array_equal(restored.layers[0].weights_in, net.layers[0].weights_in)
-    assert restored.update_type == net.update_type
+    assert restored.volatility_updates == net.volatility_updates
 
 
 def test_deepnetwork_state_is_eqx_network():
@@ -210,7 +210,7 @@ def test_deepnetwork_state_is_eqx_network():
     assert dn.state.layers[1].weights_in is not None
     assert dn.state.layers[1].weights_in.shape == (2, 4)  # (prev_size, size + bias)
     # Statics propagated from the builder.
-    assert dn.state.update_type == "unbounded"
+    assert dn.state.volatility_updates == "unbounded"
     assert dn.state.max_posterior_precision == 1e10
 
 
@@ -529,7 +529,7 @@ def test_phase8_add_layer_stack_auto_collapses_into_layerstack():
     from pyhgf.typing.vectorised import LayerStack
 
     dn = (
-        DeepNetwork(coupling_fn=jax.nn.leaky_relu, update_type="unbounded")
+        DeepNetwork(coupling_fn=jax.nn.leaky_relu, volatility_updates="unbounded")
         .add_layer(size=1, kind="binary")
         .add_layer(
             size=6,
@@ -565,7 +565,7 @@ def _phase8_build(scan, depth=5, width=6, seed=0):
     the unrolled twin.
     """
     net = (
-        DeepNetwork(coupling_fn=jax.nn.leaky_relu, update_type="unbounded")
+        DeepNetwork(coupling_fn=jax.nn.leaky_relu, volatility_updates="unbounded")
         .add_layer(size=1, kind="binary")
         .add_layer(
             size=width,

--- a/tests/test_nodes/test_continuous.py
+++ b/tests/test_nodes/test_continuous.py
@@ -74,3 +74,33 @@ def test_continuous_3_levels(volatility_updates, mean_field_updates):
     )
 
     _assert_backends_match(py_net, rs_net, 3, volatility_updates, label)
+
+
+@pytest.mark.parametrize("mean_field_updates", MEAN_FIELD_UPDATES)
+def test_continuous_nonlinear_coupling(mean_field_updates):
+    """Test a 2-level continuous HGF with a non-linear (tanh) value coupling.
+
+    Exercises the non-linear coupling branches of the posterior precision and mean
+    updates (the ``grad`` / ``grad(grad(...))`` terms), for both the relaxed and the
+    mean-field schemes. The JAX (``jnp.tanh``) and Rust (``"tanh"``) backends must
+    agree.
+    """
+    import jax.numpy as jnp
+
+    timeseries = load_data("continuous")
+    label = f"nonlinear mean_field={mean_field_updates}"
+
+    py_net = (
+        PyNetwork(volatility_updates="standard", mean_field_updates=mean_field_updates)
+        .add_nodes()
+        .add_nodes(value_children=0, coupling_fn=(jnp.tanh,))
+        .input_data(input_data=timeseries)
+    )
+    rs_net = (
+        RsNetwork(volatility_updates="standard", mean_field_updates=mean_field_updates)
+        .add_nodes()
+        .add_nodes(value_children=0, coupling_fn="tanh")
+        .input_data(input_data=timeseries)
+    )
+
+    _assert_backends_match(py_net, rs_net, 2, "standard", label)

--- a/tests/test_nodes/test_continuous.py
+++ b/tests/test_nodes/test_continuous.py
@@ -1,62 +1,76 @@
 # Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
 
 import numpy as np
+import pytest
 from pyhgf.rshgf import Network as RsNetwork
 
 from pyhgf import load_data
 from pyhgf.model import Network as PyNetwork
 
-NETWORK_CLASSES = [PyNetwork, RsNetwork]
+VOLATILITY_UPDATES = ["standard", "eHGF", "unbounded"]
+MEAN_FIELD_UPDATES = [False, True]
 
 
-def test_continuous_2_levels():
-    """Test the 2-level continuous HGF: input node → value parent."""
+def _build_network(cls, volatility_updates, mean_field_updates, n_levels, timeseries):
+    """Build an ``n_levels`` continuous HGF with the given update scheme."""
+    net = cls(
+        volatility_updates=volatility_updates,
+        mean_field_updates=mean_field_updates,
+    )
+    net = net.add_nodes().add_nodes(value_children=0)
+    if n_levels == 3:
+        net = net.add_nodes(volatility_children=0)
+    return net.input_data(input_data=timeseries)
+
+
+def _assert_backends_match(py_net, rs_net, n_levels, volatility_updates, label):
+    """Assert the JAX and Rust trajectories agree for every node."""
+    # The unbounded posterior kernel differs at the float level between the two
+    # backends (mathematically equivalent but distinct implementations), so the
+    # cross-backend comparison is loosened when a volatility parent is present.
+    rtol = 1e-1 if (volatility_updates == "unbounded" and n_levels == 3) else 1e-4
+    for node_idx in range(n_levels):
+        for key in ["mean", "expected_mean", "precision", "expected_precision"]:
+            assert np.allclose(
+                py_net.node_trajectories[node_idx][key],
+                rs_net.node_trajectories[node_idx][key],
+                rtol=rtol,
+            ), f"{label}: node {node_idx}, key '{key}' mismatch"
+
+
+@pytest.mark.parametrize("mean_field_updates", MEAN_FIELD_UPDATES)
+def test_continuous_2_levels(mean_field_updates):
+    """Test the 2-level continuous HGF: input node → value parent.
+
+    The value parent has no volatility children, so ``volatility_updates`` does not
+    affect its update path and is not parametrized here. The JAX and Rust backends must
+    produce identical trajectories for both values of ``mean_field_updates``.
+    """
     timeseries = load_data("continuous")
+    label = f"mean_field={mean_field_updates}"
 
-    results = {}
-    for cls in NETWORK_CLASSES:
-        results[cls.__name__] = (
-            cls()
-            .add_nodes()
-            .add_nodes(value_children=0)
-            .input_data(input_data=timeseries)
-        )
+    py_net = _build_network(PyNetwork, "standard", mean_field_updates, 2, timeseries)
+    rs_net = _build_network(RsNetwork, "standard", mean_field_updates, 2, timeseries)
 
-    # Ensure identical results across implementations
-    ref = results[NETWORK_CLASSES[0].__name__]
-    for name, net in results.items():
-        if net is ref:
-            continue
-        for node_idx in range(2):
-            for key in ["mean", "expected_mean", "precision", "expected_precision"]:
-                assert np.isclose(
-                    ref.node_trajectories[node_idx][key],
-                    net.node_trajectories[node_idx][key],
-                ).all(), f"{name} node {node_idx}, key '{key}' mismatch"
+    _assert_backends_match(py_net, rs_net, 2, "standard", label)
 
 
-def test_continuous_3_levels():
-    """Test the 3-level continuous HGF: input → value parent + volatility parent."""
+@pytest.mark.parametrize("volatility_updates", VOLATILITY_UPDATES)
+@pytest.mark.parametrize("mean_field_updates", MEAN_FIELD_UPDATES)
+def test_continuous_3_levels(volatility_updates, mean_field_updates):
+    """Test the 3-level continuous HGF: input → value parent + volatility parent.
+
+    The JAX and Rust backends must produce identical trajectories for every combination
+    of ``volatility_updates`` and ``mean_field_updates``.
+    """
     timeseries = load_data("continuous")
+    label = f"vol={volatility_updates} mean_field={mean_field_updates}"
 
-    results = {}
-    for cls in NETWORK_CLASSES:
-        results[cls.__name__] = (
-            cls()
-            .add_nodes()
-            .add_nodes(value_children=0)
-            .add_nodes(volatility_children=0)
-            .input_data(input_data=timeseries)
-        )
+    py_net = _build_network(
+        PyNetwork, volatility_updates, mean_field_updates, 3, timeseries
+    )
+    rs_net = _build_network(
+        RsNetwork, volatility_updates, mean_field_updates, 3, timeseries
+    )
 
-    # Ensure identical results across implementations
-    ref = results[NETWORK_CLASSES[0].__name__]
-    for name, net in results.items():
-        if net is ref:
-            continue
-        for node_idx in range(3):
-            for key in ["mean", "expected_mean", "precision", "expected_precision"]:
-                assert np.isclose(
-                    ref.node_trajectories[node_idx][key],
-                    net.node_trajectories[node_idx][key],
-                ).all(), f"{name} node {node_idx}, key '{key}' mismatch"
+    _assert_backends_match(py_net, rs_net, 3, volatility_updates, label)

--- a/tests/test_nodes/test_volatile.py
+++ b/tests/test_nodes/test_volatile.py
@@ -1,10 +1,13 @@
 # Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
 
 import numpy as np
+import pytest
 from pyhgf.rshgf import Network as RsNetwork
 
 from pyhgf import load_data
 from pyhgf.model import Network as PyNetwork
+
+UPDATE_TYPES = ["standard", "eHGF", "unbounded"]
 
 
 def _assert_value_level_match(net_a, node_a, net_b, node_b, label="", rtol=1e-5):
@@ -36,10 +39,10 @@ def _assert_vol_level_match(
         ), f"{label}: Volatility-level key '{vol_key}' vs '{explicit_key}' mismatch"
 
 
-def _build_volatile(cls, update_type, timeseries):
+def _build_volatile(cls, update_type, timeseries, mean_field_updates=False):
     """Build a volatile-state network with autoconnection for equivalence testing."""
     return (
-        cls(volatility_updates=update_type)
+        cls(volatility_updates=update_type, mean_field_updates=mean_field_updates)
         .add_nodes()
         .add_nodes(
             kind="volatile-state",
@@ -50,10 +53,10 @@ def _build_volatile(cls, update_type, timeseries):
     )
 
 
-def _build_explicit(cls, update_type, timeseries):
+def _build_explicit(cls, update_type, timeseries, mean_field_updates=False):
     """Build explicit continuous + volatility-parent network."""
     return (
-        cls(volatility_updates=update_type)
+        cls(volatility_updates=update_type, mean_field_updates=mean_field_updates)
         .add_nodes()
         .add_nodes(value_children=0)
         .add_nodes(volatility_children=1)
@@ -126,7 +129,7 @@ def test_explicit_cross_backend_unbounded():
     _run_explicit_cross_backend("unbounded")
 
 
-def _run_volatile_input_invariance(cls, label):
+def _run_volatile_input_invariance(cls, label, mean_field_updates=False):
     """Vary ``tonic_volatility`` of a volatile-state input/leaf node.
 
     The input/leaf node has no value children, so it does not undergo a Gaussian random
@@ -138,7 +141,10 @@ def _run_volatile_input_invariance(cls, label):
     expected_precisions = []
     for omega in [-8.0, 0.0]:
         net = (
-            cls(volatility_updates="unbounded")
+            cls(
+                volatility_updates="unbounded",
+                mean_field_updates=mean_field_updates,
+            )
             .add_nodes(
                 kind="volatile-state",
                 tonic_volatility=omega,
@@ -173,3 +179,186 @@ def test_volatile_input_node_invariant_to_tonic_volatility_python():
 def test_volatile_input_node_invariant_to_tonic_volatility_rust():
     """Per-node Rust: volatile-state input ignores tonic_volatility."""
     _run_volatile_input_invariance(RsNetwork, "rs")
+
+
+def _assert_volatile_node_cross_backend(net_py, net_rs, node, label="", rtol=1e-4):
+    """Assert a volatile node's trajectories match across backends."""
+    keys = [
+        "mean",
+        "expected_mean",
+        "precision",
+        "expected_precision",
+        "mean_vol",
+        "expected_mean_vol",
+        "precision_vol",
+        "expected_precision_vol",
+    ]
+    for key in keys:
+        assert np.allclose(
+            net_py.node_trajectories[node][key],
+            net_rs.node_trajectories[node][key],
+            rtol=rtol,
+        ), f"{label}: key '{key}' mismatch"
+
+
+@pytest.mark.parametrize("update_type", UPDATE_TYPES)
+def test_volatile_mean_field_cross_backend(update_type):
+    """JAX and Rust agree for volatile-state nodes with ``mean_field_updates=True``.
+
+    Exercises the mean-field prediction and posterior paths of the volatile-state node
+    (the ``_mean_field`` update functions), which the relaxed-default tests above do not
+    cover.
+    """
+    timeseries = load_data("continuous")
+
+    vol_py = _build_volatile(
+        PyNetwork, update_type, timeseries, mean_field_updates=True
+    )
+    vol_rs = _build_volatile(
+        RsNetwork, update_type, timeseries, mean_field_updates=True
+    )
+
+    # Unbounded path: Python and Rust use mathematically equivalent but float-distinct
+    # unbounded posterior kernels (see _run_explicit_cross_backend).
+    rtol = 1e-1 if update_type == "unbounded" else 1e-4
+    _assert_volatile_node_cross_backend(
+        vol_py, vol_rs, 1, f"{update_type} mean_field py vs rs", rtol=rtol
+    )
+
+
+@pytest.mark.parametrize("update_type", UPDATE_TYPES)
+def test_explicit_mean_field_cross_backend(update_type):
+    """JAX and Rust agree for explicit continuous+vol-parent with mean-field updates."""
+    timeseries = load_data("continuous")
+
+    exp_py = _build_explicit(
+        PyNetwork, update_type, timeseries, mean_field_updates=True
+    )
+    exp_rs = _build_explicit(
+        RsNetwork, update_type, timeseries, mean_field_updates=True
+    )
+
+    label = f"{update_type} mean_field py vs rs"
+    rtol = 1e-1 if update_type == "unbounded" else 1e-4
+    _assert_value_level_match(exp_py, 0, exp_rs, 0, f"{label} input", rtol=rtol)
+    _assert_value_level_match(exp_py, 1, exp_rs, 1, label, rtol=rtol)
+    _assert_value_level_match(exp_py, 2, exp_rs, 2, label, rtol=rtol)
+
+
+def test_volatile_input_node_invariant_mean_field_python():
+    """Per-node Python: volatile-state input ignores tonic_volatility (mean-field)."""
+    _run_volatile_input_invariance(PyNetwork, "py mean_field", mean_field_updates=True)
+
+
+def test_volatile_input_node_invariant_mean_field_rust():
+    """Per-node Rust: volatile-state input ignores tonic_volatility (mean-field)."""
+    _run_volatile_input_invariance(RsNetwork, "rs mean_field", mean_field_updates=True)
+
+
+def _build_volatile_value_parent(coupling_fn, mean_field_updates, timeseries):
+    """Build a volatile-state value parent coupled to its child via ``coupling_fn``."""
+    net = PyNetwork(
+        volatility_updates="standard", mean_field_updates=mean_field_updates
+    ).add_nodes()
+    if coupling_fn is None:
+        net = net.add_nodes(
+            kind="volatile-state", value_children=0, autoconnection_strength=1.0
+        )
+    else:
+        net = net.add_nodes(
+            kind="volatile-state",
+            value_children=0,
+            autoconnection_strength=1.0,
+            coupling_fn=coupling_fn,
+        )
+    return net.input_data(input_data=timeseries)
+
+
+@pytest.mark.parametrize("mean_field_updates", [False, True])
+def test_volatile_nonlinear_coupling(mean_field_updates):
+    """Volatile-state node with non-linear (tanh) value coupling (JAX).
+
+    Exercises the non-linear coupling branches (the ``grad`` / ``grad(grad(...))``
+    terms) of the volatile-state value-level precision and mean updates, in both the
+    relaxed and mean-field schemes. The trajectories must stay finite, and the
+    non-linear coupling must actually change the result relative to linear coupling.
+
+    The two backends are not compared here: the ``tanh``-coupled volatile node (with
+    autoconnection and an implicit volatility level) is numerically sensitive, so the
+    JAX and Rust trajectories diverge over time despite using the same update rule.
+    """
+    import jax.numpy as jnp
+
+    timeseries = load_data("continuous")
+    nonlinear = _build_volatile_value_parent(
+        (jnp.tanh,), mean_field_updates, timeseries
+    )
+    linear = _build_volatile_value_parent(None, mean_field_updates, timeseries)
+
+    label = f"nonlinear mean_field={mean_field_updates}"
+    for key in ["mean", "expected_mean", "precision", "expected_precision"]:
+        values = np.asarray(nonlinear.node_trajectories[1][key])
+        assert np.all(np.isfinite(values)), f"{label}: non-finite '{key}'"
+
+    # The tanh coupling must change the value-level trajectory relative to linear.
+    assert not np.allclose(
+        nonlinear.node_trajectories[1]["mean"],
+        linear.node_trajectories[1]["mean"],
+    ), f"{label}: tanh coupling did not change the trajectory"
+
+
+def _build_volatile_value_child(coupling_fn, mean_field_updates, timeseries):
+    """Build a volatile-state node that is the value *child* of a volatile parent.
+
+    The parent → child edge carries ``coupling_fn``, so the child's prediction step
+    reads the parent's expected mean through that coupling. A volatile parent is used
+    (rather than a continuous one) because continuous parents read their children's
+    ``observed`` flag, which volatile-state nodes do not expose.
+    """
+    net = PyNetwork(
+        volatility_updates="standard", mean_field_updates=mean_field_updates
+    ).add_nodes()
+    net = net.add_nodes(kind="volatile-state", value_children=0)  # node 1: child
+    # The parent (node 2) carries its mean forward (autoconnection_strength=1.0) so it
+    # drifts away from 0; otherwise its expected mean stays at 0, where tanh(0) == 0
+    # is indistinguishable from linear coupling.
+    if coupling_fn is None:
+        net = net.add_nodes(
+            kind="volatile-state", value_children=1, autoconnection_strength=1.0
+        )
+    else:
+        net = net.add_nodes(
+            kind="volatile-state",
+            value_children=1,
+            autoconnection_strength=1.0,
+            coupling_fn=coupling_fn,
+        )
+    return net.input_data(input_data=timeseries)
+
+
+@pytest.mark.parametrize("mean_field_updates", [False, True])
+def test_volatile_nonlinear_value_parent(mean_field_updates):
+    """Volatile-state node with a non-linearly-coupled value parent (JAX).
+
+    Exercises the prediction-step non-linear coupling branches
+    (:func:`predict_mean_value_level` and the relaxed
+    :func:`predict_precision_value_level`) for a volatile node that sits *below* a
+    ``tanh``-coupled value parent. The trajectories must stay finite, and the non-linear
+    coupling must change the result relative to linear coupling.
+    """
+    import jax.numpy as jnp
+
+    timeseries = load_data("continuous")
+    nonlinear = _build_volatile_value_child((jnp.tanh,), mean_field_updates, timeseries)
+    linear = _build_volatile_value_child(None, mean_field_updates, timeseries)
+
+    label = f"nonlinear value parent mean_field={mean_field_updates}"
+    for key in ["mean", "expected_mean", "precision", "expected_precision"]:
+        values = np.asarray(nonlinear.node_trajectories[1][key])
+        assert np.all(np.isfinite(values)), f"{label}: non-finite '{key}'"
+
+    # The tanh coupling on the parent edge must change the child's trajectory.
+    assert not np.allclose(
+        nonlinear.node_trajectories[1]["mean"],
+        linear.node_trajectories[1]["mean"],
+    ), f"{label}: tanh coupling did not change the trajectory"

--- a/tests/test_nodes/test_volatile.py
+++ b/tests/test_nodes/test_volatile.py
@@ -39,7 +39,7 @@ def _assert_vol_level_match(
 def _build_volatile(cls, update_type, timeseries):
     """Build a volatile-state network with autoconnection for equivalence testing."""
     return (
-        cls(update_type=update_type)
+        cls(volatility_updates=update_type)
         .add_nodes()
         .add_nodes(
             kind="volatile-state",
@@ -53,7 +53,7 @@ def _build_volatile(cls, update_type, timeseries):
 def _build_explicit(cls, update_type, timeseries):
     """Build explicit continuous + volatility-parent network."""
     return (
-        cls(update_type=update_type)
+        cls(volatility_updates=update_type)
         .add_nodes()
         .add_nodes(value_children=0)
         .add_nodes(volatility_children=1)
@@ -138,7 +138,7 @@ def _run_volatile_input_invariance(cls, label):
     expected_precisions = []
     for omega in [-8.0, 0.0]:
         net = (
-            cls(update_type="unbounded")
+            cls(volatility_updates="unbounded")
             .add_nodes(
                 kind="volatile-state",
                 tonic_volatility=omega,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,7 +82,7 @@ def test_set_update_sequence():
 
     # a standard continuous HGF
     network2 = (
-        Network(update_type="standard")
+        Network(volatility_updates="standard")
         .add_nodes()
         .add_nodes(value_children=0)
         .add_nodes(volatility_children=1)
@@ -244,7 +244,7 @@ def test_learning():
 
     # fixed learning rate
     network = (
-        Network(update_type="unbounded")
+        Network(volatility_updates="unbounded")
         .add_nodes(n_nodes=2, precision=2.0, expected_precision=2.0)
         .add_nodes(
             value_children=[0, 1],
@@ -258,7 +258,7 @@ def test_learning():
 
     # Kalman-gain learning rule with a fixed step size
     network = (
-        Network(update_type="unbounded")
+        Network(volatility_updates="unbounded")
         .add_nodes(n_nodes=2, precision=2.0, expected_precision=2.0)
         .add_nodes(
             value_children=[0, 1],


### PR DESCRIPTION
## Rename `update_type` → `volatility_updates` and add `mean_field_updates`

### Summary
Renames the `Network` constructor parameter `update_type` to the clearer `volatility_updates`, and adds a new `mean_field_updates` flag that lets users select between the current relaxed updates and the original mean-field updates.

### Changes

**Parameter rename**
- `update_type` → `volatility_updates` across the JAX `Network`, the Rust `Network`, `DeepNetwork`, the vectorized typing, and all tests/notebooks.
- The internal `get_update_sequence` keyword argument is unchanged; only the public constructor argument was renamed.

**New `mean_field_updates` flag**
- `mean_field_updates=False` (default) keeps the current relaxed prediction/posterior updates. No change to existing behavior.
- `mean_field_updates=True` selects the original mean-field updates (no Schur-complement / Laplace / MGF corrections).
- Implemented as `_mean_field` variants of the prediction and posterior steps in both the JAX and Rust backends, wired through `get_update_sequence` (JAX) and `set_sequence` + new `UpdateStep` variants (Rust). Applies to the JAX nodalised and Rust backends.

**Tests**
- `test_continuous.py` now parametrizes over all combinations of `volatility_updates` (`standard`, `eHGF`, `unbounded`) and `mean_field_updates` (`False`, `True`), asserting the JAX and Rust backends produce identical trajectories. The 2-level test omits `volatility_updates` since it has no effect without a volatility parent.

**Docs**
- Updated all docstrings to cite the 2026 eLife gHGF paper (`doi:10.7554/elife.110174.1`) and removed the 2023 arXiv reference.
- Updated `Network`/`DeepNetwork` calls in the docs notebooks to the new parameter name.

### Compatibility
`mean_field_updates` defaults to the existing relaxed behavior, so results are unchanged unless explicitly opted out. The `update_type` rename is a breaking change for any code passing it as a keyword.
