### PR TITLE
fix bias under non linear coupling in the vectorised backend

### DIFF
--- a/pyhgf/updates/vectorized/volatile/prediction.py
+++ b/pyhgf/updates/vectorized/volatile/prediction.py
@@ -65,9 +65,11 @@ def vectorized_layer_prediction(
         Coupling function applied to parent means (default :func:`jax.numpy.tanh`).
     parent_has_constant :
         If True, the parent layer has a constant input node (mean = 1.0)
-        appended to its activations. The last column of *weights* carries the bias
-        connections; its predicted precision is treated as infinite so it
-        contributes zero to the value-coupling variance.
+        appended to its activations. The last column of *weights* carries the
+        bias connections and is treated as linearly coupled (:math:`g(1) = 1`),
+        regardless of *coupling_fn*; the constant node's derivative is zero and
+        its predicted precision is infinite, so it contributes nothing to the
+        value-coupling variance.
     has_volatility_parent :
         If True (default), the layer has an implied internal volatility parent
         whose state (``mean_vol``, ``precision_vol``) is predicted and updated.
@@ -119,11 +121,14 @@ def vectorized_layer_prediction(
     # Mean prediction via matrix multiply
     # weights shape: (n_children, n_parents) or (n_children, n_parents + 1)
     # parent_state.expected_mean shape: (n_parents,)
-    parent_mean = parent_state.expected_mean
+    # Apply coupling to the parent activations only; the constant bias node is
+    # always wired in linearly (g(1) = 1) regardless of coupling_fn — the same
+    # convention as the binary prediction, the weight-learning step, the
+    # per-node backend, and the Rust backend (constant-state nodes are forced
+    # to identity coupling).
+    coupled_parents = coupling_fn(parent_state.expected_mean)
     if parent_has_constant:
-        # Append constant 1.0 for bias node before applying coupling_fn
-        parent_mean = jnp.concatenate([parent_mean, jnp.ones(1)])
-    coupled_parents = coupling_fn(parent_mean)
+        coupled_parents = jnp.concatenate([coupled_parents, jnp.ones(1)])
 
     # Expected mean for value level
     # Note: autoconnection_strength = 0 for i.i.d. classification
@@ -157,9 +162,11 @@ def vectorized_layer_prediction(
     # using the parent's marginal predicted precision π̃_j (= `expected_precision`).
     # The constant-bias parent (if any) has infinite precision and contributes zero.
     parent_precision = parent_state.expected_precision
+    g_prime = vmap(grad(coupling_fn))(parent_state.expected_mean)
     if parent_has_constant:
+        # The constant node never varies: zero derivative, infinite precision.
         parent_precision = jnp.concatenate([parent_precision, jnp.array([jnp.inf])])
-    g_prime = vmap(grad(coupling_fn))(parent_mean)
+        g_prime = jnp.concatenate([g_prime, jnp.zeros(1)])
     weighted_grad = weights * (time_step * g_prime)
     value_coupling_variance = jnp.sum(weighted_grad**2 / parent_precision, axis=-1)
 

--- a/tests/test_deepnetwork.py
+++ b/tests/test_deepnetwork.py
@@ -1,5 +1,7 @@
 # Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
 
+import dataclasses
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -658,3 +660,42 @@ def test_input_layer_invariant_to_tonic_volatility():
         ),
     )
     np.testing.assert_allclose(expected_precisions[0], 5.0, rtol=1e-5)
+
+
+def test_constant_input_is_linearly_coupled():
+    """The bias enters predictions linearly, whatever the coupling function.
+
+    A Linear -> GELU -> Linear network with bias columns must compute
+    ``W1 @ gelu(W2 @ x + b2) + b1``: the constant bias node is wired in
+    linearly (``g(1) = 1``), the same convention as the weight-learning step,
+    the per-node backend, and the Rust backend (both force constant-state
+    nodes to identity coupling). Applying the coupling function to the
+    constant node would instead scale every bias by ``gelu(1)`` (~0.84), so
+    the network would learn against a different forward function than the one
+    it computes.
+    """
+    rng = np.random.default_rng(3)
+    d, h = 4, 6
+    w1 = jnp.asarray(rng.normal(size=(d, h)))
+    b1 = jnp.asarray(rng.normal(size=(d,)))
+    w2 = jnp.asarray(rng.normal(size=(h, d)))
+    b2 = jnp.asarray(rng.normal(size=(h,)))
+    x = jnp.asarray(rng.normal(size=(d,)))
+
+    net = (
+        DeepNetwork()
+        .add_layer(size=d)  # output layer
+        .add_layer(size=h, coupling_fn=jax.nn.gelu)  # hidden, GELU coupling
+        .add_layer(size=d)  # input layer
+    )
+    elements = list(net.state.layers)
+    elements[1] = dataclasses.replace(
+        elements[1], weights_in=jnp.concatenate([w1, b1[:, None]], axis=1)
+    )
+    elements[2] = dataclasses.replace(
+        elements[2], weights_in=jnp.concatenate([w2, b2[:, None]], axis=1)
+    )
+    net.state = dataclasses.replace(net.state, layers=tuple(elements))
+
+    expected = w1 @ jax.nn.gelu(w2 @ x + b2) + b1
+    np.testing.assert_allclose(net.predict(x), expected, rtol=1e-5, atol=1e-6)


### PR DESCRIPTION
## Apply the coupling function to parent activations only, not the constant bias node

The vectorized volatile prediction kernel appended the constant bias node **before** applying the coupling function, so the bias entered the forward pas scaled by `coupling_fn(1)` (×0.84 for GELU). Everything else treats the bias as linear, so networks with `add_constant_input=True` and a non-identity coupling are learned against a different forward function than the one they computed.

Fix: apply `coupling_fn` to the real parent activations only, then append the constant `1.0`; the constant node gets a zero derivative and infinite precision in the value-coupling variance term. A biased network now computes `W1 @ gelu(W2 @ x + b2) + b1`, consistent with its own learning rule.

Tests: new regression test `test_constant_input_is_linearly_coupled` (fails by ~16% of each bias term on the old kernel); full suite passes (26/26), including the three-backend parity tests.