### PR TITLE
Sync Cargo.lock with the 0.3.0 version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rshgf"
-version = "0.2.12"
+version = "0.3.0"
 dependencies = [
  "numpy",
  "pyo3",


### PR DESCRIPTION
The 0.2.12 -> 0.3.0 bump (#395) updated Cargo.toml but not the lockfile.