### PR TITLE
Store volatility levels as None on layers without a volatility parent

### DIFF
--- a/pyhgf/typing/vectorised.py
+++ b/pyhgf/typing/vectorised.py
@@ -57,17 +57,34 @@ class LayerState(eqx.Module):
     conditional_expected_precision: Array
     effective_precision: Array
     value_prediction_error: Array
-    # Volatility level (internal)
-    mean_vol: Array
-    precision_vol: Array
-    expected_mean_vol: Array
-    expected_precision_vol: Array
-    effective_precision_vol: Array
-    volatility_prediction_error: Array
+    # Volatility level (internal). ``None`` when the layer has no volatility
+    # parent (see :meth:`create`).
+    mean_vol: Optional[Array]
+    precision_vol: Optional[Array]
+    expected_mean_vol: Optional[Array]
+    expected_precision_vol: Optional[Array]
+    effective_precision_vol: Optional[Array]
+    volatility_prediction_error: Optional[Array]
 
     @classmethod
-    def create(cls, n_nodes: int) -> "LayerState":
-        """Initialise a layer state with defaults."""
+    def create(cls, n_nodes: int, has_volatility_parent: bool = True) -> "LayerState":
+        """Initialise a layer state with defaults.
+
+        With ``has_volatility_parent=False`` the six volatility-level fields are
+        set to ``None`` instead of being allocated. A frozen volatility level is
+        never predicted or updated. Every access to these fields sits behind a
+        ``has_volatility_parent`` guard (see
+        :func:`pyhgf.updates.vectorized.volatile.prediction` and
+        :mod:`~pyhgf.updates.vectorized.volatile.prediction_error`), so storing
+        them would only carry dead arrays through the state. As ``None`` pytree
+        nodes they hold no data and are skipped by every ``tree_map`` over the
+        state (stacking, scanning, recording).
+        """
+        vol = (
+            (lambda v: jnp.full(n_nodes, v))
+            if has_volatility_parent
+            else (lambda v: None)
+        )
         return cls(
             mean=jnp.zeros(n_nodes),
             precision=jnp.ones(n_nodes),
@@ -76,13 +93,25 @@ class LayerState(eqx.Module):
             conditional_expected_precision=jnp.ones(n_nodes),
             effective_precision=jnp.zeros(n_nodes),
             value_prediction_error=jnp.zeros(n_nodes),
-            mean_vol=jnp.zeros(n_nodes),
-            precision_vol=jnp.ones(n_nodes),
-            expected_mean_vol=jnp.zeros(n_nodes),
-            expected_precision_vol=jnp.ones(n_nodes),
-            effective_precision_vol=jnp.zeros(n_nodes),
-            volatility_prediction_error=jnp.zeros(n_nodes),
+            mean_vol=vol(0.0),
+            precision_vol=vol(1.0),
+            expected_mean_vol=vol(0.0),
+            expected_precision_vol=vol(1.0),
+            effective_precision_vol=vol(0.0),
+            volatility_prediction_error=vol(0.0),
         )
+
+
+# The six volatility-level fields of :class:`LayerState`, set to ``None`` on a
+# layer without a volatility parent (see :meth:`LayerState.create`).
+VOLATILITY_STATE_FIELDS: tuple = (
+    "mean_vol",
+    "precision_vol",
+    "expected_mean_vol",
+    "expected_precision_vol",
+    "effective_precision_vol",
+    "volatility_prediction_error",
+)
 
 
 class LayerParams(eqx.Module):

--- a/pyhgf/updates/vectorized/volatile/prediction.py
+++ b/pyhgf/updates/vectorized/volatile/prediction.py
@@ -4,10 +4,10 @@
 """Vectorized prediction update for volatile node layers."""
 
 import dataclasses
-from typing import Callable
+from typing import Callable, Optional
 
 import jax.numpy as jnp
-from jax import grad, vmap
+from jax import Array, grad, vmap
 
 from pyhgf.typing.vectorised import LayerParams, LayerState
 
@@ -92,7 +92,12 @@ def vectorized_layer_prediction(
     """
     # 1. VOLATILITY LEVEL PREDICTION (internal) ----------------------------------------
     # ----------------------------------------------------------------------------------
+    expected_mean_vol: Optional[Array]
+    expected_precision_vol: Optional[Array]
+    effective_precision_vol: Optional[Array]
     if has_volatility_parent:
+        assert child_state.mean_vol is not None
+        assert child_state.precision_vol is not None
         # Expected mean for volatility level
         expected_mean_vol = params.autoconnection_strength_vol * child_state.mean_vol
 
@@ -137,6 +142,8 @@ def vectorized_layer_prediction(
     expected_mean = jnp.matmul(weights, coupled_parents)
 
     if has_volatility_parent:
+        assert expected_mean_vol is not None
+        assert expected_precision_vol is not None
         # Total volatility includes contribution from internal volatility level
         # plus the closed-form moment-generating-function correction
         # κ² / (2 · π̂_vol) that arises from marginalising over the volatility
@@ -167,8 +174,12 @@ def vectorized_layer_prediction(
         # The constant node never varies: zero derivative, infinite precision.
         parent_precision = jnp.concatenate([parent_precision, jnp.array([jnp.inf])])
         g_prime = jnp.concatenate([g_prime, jnp.zeros(1)])
-    weighted_grad = weights * (time_step * g_prime)
-    value_coupling_variance = jnp.sum(weighted_grad**2 / parent_precision, axis=-1)
+    # Σ_j (t · W[i, j] · g'_j)² / π_j, computed as (W²) @ ((t · g')² / π): the
+    # weight-dependent factor is a constant matrix, so the per-node sum is a
+    # matrix product with a per-node vector — no weight-matrix-sized
+    # intermediate, which matters when this function is vmapped over a batch.
+    per_parent_variance = (time_step * g_prime) ** 2 / parent_precision
+    value_coupling_variance = jnp.matmul(weights**2, per_parent_variance)
 
     # Conditional predicted precision π̂_a — the precision of x_a given a specific
     # value of x_b (own AR-plus-volatility variance only, no parent-uncertainty

--- a/pyhgf/updates/vectorized/volatile/prediction_error.py
+++ b/pyhgf/updates/vectorized/volatile/prediction_error.py
@@ -116,6 +116,8 @@ def vectorized_layer_volatility_posterior_standard(
     --------
     :mod:`pyhgf.updates.posterior.volatile.posterior_update_volatility_level`
     """
+    assert layer.expected_precision_vol is not None
+    assert layer.expected_mean_vol is not None
     volatility_prediction_error = layer.volatility_prediction_error
     volatility_coupling = params.volatility_coupling
     effective_precision = layer.effective_precision
@@ -182,6 +184,8 @@ def vectorized_layer_volatility_posterior_ehgf(
     LayerState
         Updated layer state with ``precision_vol`` and ``mean_vol`` set.
     """
+    assert layer.expected_precision_vol is not None
+    assert layer.expected_mean_vol is not None
     volatility_coupling = params.volatility_coupling
     tonic_volatility = params.tonic_volatility
 
@@ -274,6 +278,8 @@ def vectorized_layer_volatility_posterior_unbounded(
     LayerState
         Updated layer state with ``precision_vol`` and ``mean_vol`` set.
     """
+    assert layer.expected_precision_vol is not None
+    assert layer.expected_mean_vol is not None
     volatility_coupling = params.volatility_coupling
     tonic_volatility = params.tonic_volatility
 

--- a/pyhgf/utils/vectorized_belief_propagation.py
+++ b/pyhgf/utils/vectorized_belief_propagation.py
@@ -12,7 +12,14 @@ import jax
 import jax.numpy as jnp
 import optax
 
-from pyhgf.typing.vectorised import Layer, LayerStack, Network
+from pyhgf.typing.vectorised import (
+    VOLATILITY_STATE_FIELDS as _VOL_STATE_FIELDS,
+)
+from pyhgf.typing.vectorised import (
+    Layer,
+    LayerStack,
+    Network,
+)
 from pyhgf.updates.vectorized.binary import (
     vectorized_binary_prediction,
     vectorized_binary_prediction_error,
@@ -280,6 +287,35 @@ def _posterior_pe_layer(
     return dataclasses.replace(parent, state=new_state)
 
 
+def _match_child_vol_structure(child_state, has_volatility_parent):
+    """Align a child state's volatility fields to a consumer's volatility structure.
+
+    A layer without a volatility parent stores its six volatility fields as
+    ``None`` rather than arrays. Where such a child meets a ``LayerStack`` with a
+    different volatility structure — a ``scan`` carry seeded by the child, or a
+    concatenation of the child onto the stack — the two pytrees must match.
+
+    Reconciling them here is value-neutral: cross-layer coupling is value-only,
+    so a parent update never reads its child's volatility level (that level is
+    internal to each layer). Materialising zero volatility fields when the
+    consumer has them, or dropping to ``None`` when it does not, only fixes the
+    structure; no volatility quantity of the child is ever consumed.
+    """
+    if has_volatility_parent:
+        n = child_state.mean.shape[-1]
+        repl = {
+            f: (
+                jnp.zeros(n)
+                if getattr(child_state, f) is None
+                else getattr(child_state, f)
+            )
+            for f in _VOL_STATE_FIELDS
+        }
+    else:
+        repl = {f: None for f in _VOL_STATE_FIELDS}
+    return dataclasses.replace(child_state, **repl)
+
+
 def _posterior_pe_stack(
     stack: LayerStack,
     child_state_init,
@@ -296,6 +332,11 @@ def _posterior_pe_stack(
     ``child_is_input_layer=False`` throughout — Phase 8 v1 requires the layer below a
     stack to be non-leaf, so the boundary is interior.
     """
+    # The scan carry becomes a stack slice each step, so seed it with the
+    # child's state coerced to the stack's volatility structure.
+    child_state_init = _match_child_vol_structure(
+        child_state_init, stack.has_volatility_parent
+    )
 
     def body(child_carry_state, slice_data):
         slice_state, slice_params, slice_weights = slice_data
@@ -377,6 +418,7 @@ def _grad_stack(stack: LayerStack, child_elem, learning_kind: str):
     slice grad over the N parent slices and the N child slots.
     """
     child_state, _, _ = _child_view(child_elem)
+    child_state = _match_child_vol_structure(child_state, stack.has_volatility_parent)
 
     combined_state = jax.tree_util.tree_map(
         lambda c, s: jnp.concatenate([c[None, ...], s], axis=0),


### PR DESCRIPTION
A frozen volatility level is never predicted or updated, so allocating its six `LayerState` fields only carries dead arrays through every `tree_map` over the state (stacking, scanning, recording). `LayerState.create(has_volatility_parent=False)` now sets them to `None`; `_match_child_vol_structure` reconciles pytree structure where such a layer meets a `LayerStack` with a different volatility structure. Also computes the value-coupling variance in the volatile prediction as a matrix product with a per-parent vector, avoiding a weight-matrix-sized intermediate under `vmap`.