### PR TITLE
Weight updates: only keep standard and precision_weighted

### DIFF
--- a/pyhgf/model/deep_network.py
+++ b/pyhgf/model/deep_network.py
@@ -533,8 +533,9 @@ class DeepNetwork:
         learning_kind :
             Gradient computation mode passed to
             :func:`~pyhgf.updates.vectorized.learning.vectorized_weight_gradient`:
-            ``"standard"``, ``"precision_weighted"`` (default),
-            ``"precision_ratio"``, ``"map_natural"``, or ``"pure_natural"``.
+            ``"standard"`` or ``"precision_weighted"`` (default). Both are
+            strictly local. Each weight update reads only its own
+            connection's prediction error, activation, and precision.
         record :
             Tuple of ``LayerState`` field names to record at every time step,
             e.g. ``("expected_mean", "precision")``. ``None`` (default) skips

--- a/pyhgf/model/network.py
+++ b/pyhgf/model/network.py
@@ -7,7 +7,7 @@ from typing import Callable, Optional, Union
 import jax.numpy as jnp
 import numpy as np
 import pandas as pd
-from jax import random, vmap
+from jax import Array, random, vmap
 from jax.lax import scan, switch
 from jax.tree_util import Partial
 from jax.typing import ArrayLike
@@ -259,11 +259,11 @@ class Network:
             `scan_fn` is already defined.
         lr :
             How the gradient is applied: a non-negative float for direct scaling, or
-            ``"adam"`` for the Adam optimiser.  Applied uniformly across all
-            *learning_kind* values, including ``"precision_ratio"``.
+            ``"adam"`` for the Adam optimiser. Applied uniformly across both
+            *learning_kind* values.
         learning_kind :
-            Gradient computation mode: ``"standard"``, ``"precision_weighted"``
-            (default), or ``"precision_ratio"``.
+            Gradient computation mode: ``"standard"`` or ``"precision_weighted"``
+            (default).
         params :
             Dictionary of Adam hyper-parameters (used only when ``lr="adam"``):
             ``beta1`` (default 0.9), ``beta2`` (default 0.999), ``epsilon``
@@ -403,8 +403,8 @@ class Network:
             How the gradient is applied: a non-negative float for direct scaling, or
             ``"adam"`` for the Adam optimiser.
         learning_kind :
-            Gradient computation mode: ``"standard"``, ``"precision_weighted"``
-            (default), or ``"precision_ratio"``.
+            Gradient computation mode: ``"standard"`` or ``"precision_weighted"``
+            (default).
         params :
             Dictionary of Adam hyper-parameters (used only when ``lr="adam"``):
             ``beta1`` (default 0.9), ``beta2`` (default 0.999), ``epsilon``
@@ -988,7 +988,7 @@ class Network:
         response_function: Callable,
         response_function_inputs: tuple = (),
         response_function_parameters: Optional[Union[tuple, ArrayLike, float]] = None,
-    ) -> float:
+    ) -> Array:
         """Surprise of the model conditioned by the response function.
 
         The surprise (negative log probability) depends on the input data, the model

--- a/pyhgf/updates/learning.py
+++ b/pyhgf/updates/learning.py
@@ -30,21 +30,15 @@ def learning_weights(
       precision weighting.
       :math:`g_i = \text{PE} \cdot g(\text{parent}_i)`
     - **precision_weighted** (``kind="precision_weighted"``): gradient weighted
-      by the child posterior precision.
+      by the child *posterior* precision (the backprop-parity choice: it cancels
+      the posterior-precision division in the belief shift).
       :math:`g_i = \text{PE} \cdot \pi_\text{child} \cdot g(\text{parent}_i)`
-    - **precision_ratio** (``kind="precision_ratio"``): Kalman-gain-weighted PE
-      using the posterior precisions of child and parent.
-      :math:`K_i = \pi_\text{child} / (\pi_{\text{parent}_i} + \pi_\text{child})`
-      :math:`g_i = K_i \cdot \text{PE} \cdot g(\text{parent}_i)`
 
-    *lr* controls how the gradient is applied (same semantics for all three kinds):
+    *lr* controls how the gradient is applied (same semantics for both kinds):
 
     - **Adam** (``adam_beta1`` is a float): gradient filtered through Adam;
       step size controlled by *lr*.
     - **Fixed** (``adam_beta1`` is None): :math:`\Delta w_i = \text{lr} \cdot g_i`.
-
-    To recover the old "full Kalman step" behaviour for ``kind="precision_ratio"``,
-    pass ``lr=1.0``.
 
     Parameters
     ----------
@@ -57,11 +51,11 @@ def learning_weights(
         :py:class:`pyhgf.typing.Indexes`. The tuple has the same length as node number.
         For each node, the index list value and volatility parents and children.
     kind :
-        Gradient computation mode: ``"standard"``, ``"precision_weighted"`` (default),
-        or ``"precision_ratio"``.
+        Gradient computation mode: ``"standard"`` or ``"precision_weighted"``
+        (default).
     lr :
-        Fixed learning rate or Adam step size.  Applied uniformly across all *kind*
-        values, including ``"precision_ratio"``.
+        Fixed learning rate or Adam step size. Applied uniformly across both
+        *kind* values.
     adam_beta1 :
         Adam first moment decay rate.  When ``None`` (default) Adam is not used.
     adam_beta2 :
@@ -106,15 +100,7 @@ def learning_weights(
     pe = attributes[node_idx]["mean"] - attributes[node_idx]["expected_mean"]
     is_binary = edges[node_idx].node_type == 1
 
-    if kind == "precision_ratio":
-        parent_precisions = jnp.array([
-            attributes[parent_idx].get("precision", 1.0)
-            for parent_idx in edges[node_idx].value_parents  # type: ignore[union-attr]
-        ])
-
-        kalman_gain = child_precision / (parent_precisions + child_precision)
-        gradient = kalman_gain * pe * prospective_activation
-    elif kind == "precision_weighted" and not is_binary:
+    if kind == "precision_weighted" and not is_binary:
         gradient = pe * child_precision * prospective_activation
     else:  # "standard", or binary child where Bernoulli variance must not be doubled
         gradient = pe * prospective_activation

--- a/pyhgf/updates/vectorized/learning.py
+++ b/pyhgf/updates/vectorized/learning.py
@@ -26,31 +26,26 @@ def vectorized_weight_gradient(
     returns ``-lr * grad``; together they reproduce the legacy ``weights + lr * g``
     rule with ``g = -grad``).
 
-    The gradient is computed according to *kind*:
+    The two *kind* values share the same base term, the value prediction error
+    :math:`\delta = \mu_\text{child} - \hat{\mu}_\text{child}` times the coupled
+    parent activation :math:`a = g(\mu_\text{parent})`; they differ only in what
+    scales it. Both are strictly *local*: the update for one weight only reads
+    the prediction error and precision at its child and the activation at its
+    parent. No reduction over other parents or children in the layer.
 
-    - **standard** (``kind="standard"``):
-      :math:`g = \text{PE} \otimes g(\text{parent})`
-    - **precision_weighted** (``kind="precision_weighted"``):
-      :math:`g = \text{PE} \otimes g(\text{parent}) \cdot \pi_\text{child}`
-    - **precision_ratio** (``kind="precision_ratio"``): Kalman-gain-style gain
-      using the parent's expected precision in the numerator.
-      :math:`K = \pi_\text{parent} / (\pi_\text{parent} + \pi_\text{child})`,
-      :math:`g = \text{PE} \otimes g(\text{parent}) \cdot K`
-    - **map_natural** (``kind="map_natural"``): MAP weight update from the
-      predictive-coding free energy with a Gaussian weight prior whose
-      precision is the parent's expected precision; combines child precision
-      (numerator) with parent prior plus per-weight Fisher curvature
-      :math:`g(\text{parent})^2` (denominator).
-      Gaussian child:
-      :math:`g = \text{PE} \otimes g(\text{parent}) \cdot \pi_\text{child} / (\pi_\text{parent} + \pi_\text{child} \cdot g(\text{parent})^2)`.
-      Binary child:
-      :math:`g = \text{PE} \otimes g(\text{parent}) / (\pi_\text{parent} + g(\text{parent})^2)`.
-    - **pure_natural** (``kind="pure_natural"``): Riemannian natural gradient
-      under the parent's precision metric.
-      Gaussian child:
-      :math:`g = \text{PE} \otimes g(\text{parent}) \cdot \pi_\text{child} / \pi_\text{parent}`.
-      Binary child:
-      :math:`g = \text{PE} \otimes g(\text{parent}) / \pi_\text{parent}`.
+    - **standard** (``kind="standard"``) — the raw gradient of an *unweighted*
+      squared error, no metric:
+      :math:`g = \delta \otimes a`.
+      This coincides with the free-energy gradient only when the child precision
+      is one (e.g. the unit-precision output / categorical convention).
+
+    - **precision_weighted** (``kind="precision_weighted"``) — the free-energy
+      gradient weighted by the child's *posterior* precision:
+      :math:`g = \delta \otimes a \cdot \pi_\text{child}`.
+      This is the **backprop-parity** mode. A moved interior belief shifts by
+      (routed error) / posterior precision, so weighting by that same posterior
+      precision cancels the division and reproduces the backpropagated gradient
+      node-for-node at *any* precision setting, not only the pinned recipe.
 
     Parameters
     ----------
@@ -66,9 +61,9 @@ def vectorized_weight_gradient(
         If True, the parent layer has a constant input node (mean = 1.0,
         precision = 1.0) appended to its activations after coupling.
     child_is_binary :
-        If True, the child layer is a binary node — drops the redundant
-        precision factor in ``precision_weighted`` / ``map_natural`` /
-        ``pure_natural`` modes (Bernoulli Fisher cancels through sigmoid).
+        If True, the child layer is a binary node drops the redundant
+        precision factor in ``precision_weighted`` (the Bernoulli variance
+        cancels through the sigmoid in the gradient).
 
     Returns
     -------
@@ -82,63 +77,87 @@ def vectorized_weight_gradient(
     ValueError
         If *kind* is unrecognised.
     """
-    _valid_kinds = (
-        "standard",
-        "precision_weighted",
-        "precision_ratio",
-        "map_natural",
-        "pure_natural",
+    # Every kind is a rank-one product of a child-side and a parent-side factor
+    # (see :func:`vectorized_weight_gradient_factors`), so the full matrix is
+    # their outer product. The factor kernel is the single home of the per-kind
+    # geometry, the descent-sign flip, and the ``kind`` validation. NaN/inf are
+    # zeroed on the two factors there rather than on the assembled matrix; the
+    # two agree except for a finite×finite overflow to inf, which neither path
+    # special-cases.
+    u, v = vectorized_weight_gradient_factors(
+        parent_state,
+        child_state,
+        coupling_fn,
+        kind=kind,
+        parent_has_constant=parent_has_constant,
+        child_is_binary=child_is_binary,
     )
-    if kind not in _valid_kinds:
-        raise ValueError(f"Unknown kind '{kind}'. Expected one of {_valid_kinds}.")
+    return u[:, None] * v[None, :]
 
-    # Prediction error at the child layer.
+
+# Both weight-update kinds factorise into a child-side and a parent-side
+# vector (a rank-one product): pe (times, for precision_weighted, the child
+# posterior precision) on one side, the coupled parent activation on the
+# other. No reduction across other parents or children. Returning the two
+# factors lets a batched caller average over samples with one contraction
+# instead of materialising a weight-matrix-sized gradient per sample.
+SEPARABLE_KINDS: tuple = ("standard", "precision_weighted")
+
+
+def vectorized_weight_gradient_factors(
+    parent_state: LayerState,
+    child_state: LayerState,
+    coupling_fn: Callable,
+    kind: str = "precision_weighted",
+    parent_has_constant: bool = False,
+    child_is_binary: bool = False,
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    r"""Child- and parent-side factors of the weight gradient.
+
+    For the separable gradient modes (:data:`SEPARABLE_KINDS`) the descent
+    gradient of :func:`vectorized_weight_gradient` is a rank-one product,
+    ``grad = u[:, None] * v[None, :]``. Returning the two vectors instead of
+    their product lets a batched caller average gradients over many samples
+    with a single contraction (``einsum('bi,bj->ij') / batch``). The same
+    arithmetic, but without materialising one weight-matrix-sized gradient
+    per sample, which is what dominates memory traffic at scale.
+
+    Non-finite entries are zeroed on the factors, matching the per-entry
+    zeroing of :func:`vectorized_weight_gradient` for vector-borne NaN/inf.
+
+    Parameters
+    ----------
+    parent_state, child_state, coupling_fn, kind, parent_has_constant, child_is_binary :
+        As in :func:`vectorized_weight_gradient`. *kind* must be one of
+        :data:`SEPARABLE_KINDS`.
+
+    Returns
+    -------
+    (u, v) :
+        Child-side factor, shape ``(n_children,)``, and parent-side factor,
+        shape ``(n_parents[+1],)``, such that ``u[:, None] * v[None, :]`` equals the
+        descent gradient.
+
+    Raises
+    ------
+    ValueError
+        If *kind* is unrecognised.
+    """
+    if kind not in SEPARABLE_KINDS:
+        raise ValueError(f"Unknown kind '{kind}'. Expected one of {SEPARABLE_KINDS}.")
+
     pe = child_state.mean - child_state.expected_mean
-
-    # Coupled parent activation. The constant bias node is wired in linearly
-    # (g(1) = 1) regardless of coupling_fn, so the bias entry is appended
-    # after the coupling has been applied to the activations.
     coupled_parent = coupling_fn(parent_state.mean)
     if parent_has_constant:
         coupled_parent = jnp.concatenate([coupled_parent, jnp.ones(1)])
 
-    # Base outer product: PE ⊗ g(parent)
-    gradient = pe[:, None] * coupled_parent[None, :]
+    u = pe
+    v = coupled_parent
+    if kind == "precision_weighted" and not child_is_binary:
+        u = u * child_state.precision  # posterior precision (backprop-parity gradient)
 
-    # Specialise by kind.
-    if kind in ("precision_ratio", "map_natural", "pure_natural"):
-        parent_precision = parent_state.expected_precision
-        if parent_has_constant:
-            # Constant state nodes have precision = 1.0 (fully known bias).
-            parent_precision = jnp.concatenate([parent_precision, jnp.ones(1)])
+    u = jnp.where(jnp.isfinite(u), u, 0.0)
+    v = jnp.where(jnp.isfinite(v), v, 0.0)
 
-    if kind == "precision_ratio" and not child_is_binary:
-        kalman_gain = parent_precision[None, :] / (
-            parent_precision[None, :] + child_state.expected_precision[:, None]
-        )
-        gradient = gradient * kalman_gain
-    elif kind == "map_natural":
-        if child_is_binary:
-            gain = 1.0 / (parent_precision[None, :] + coupled_parent[None, :] ** 2)
-        else:
-            gain = child_state.expected_precision[:, None] / (
-                parent_precision[None, :]
-                + child_state.expected_precision[:, None] * coupled_parent[None, :] ** 2
-            )
-        gradient = gradient * gain
-    elif kind == "pure_natural":
-        if child_is_binary:
-            gain = 1.0 / parent_precision[None, :]
-        else:
-            gain = child_state.expected_precision[:, None] / parent_precision[None, :]
-        gradient = gradient * gain
-    elif kind == "precision_weighted" and not child_is_binary:
-        gradient = gradient * child_state.precision[:, None]
-
-    # Zero out NaN/inf so optax moments stay finite.
-    gradient = jnp.where(jnp.isnan(gradient) | jnp.isinf(gradient), 0.0, gradient)
-
-    # Negate: HGF's natural formulation produces an ascent gradient; optax
-    # expects descent. The combination ``apply_updates(w, sgd(lr).update(grad))``
-    # reproduces ``w + lr * (-(-grad)) = w + lr * g`` matching legacy.
-    return -gradient
+    # Descent sign, folded into the child-side factor.
+    return -u, v

--- a/tests/test_deepnetwork.py
+++ b/tests/test_deepnetwork.py
@@ -29,13 +29,12 @@ def test_fit():
         (None, None),  # linear (identity)
         ("tanh", (jnp.tanh,)),  # nonlinear
     ]
-    # (learning_kind, lr, label) — lr is now applied uniformly to all kinds,
-    # including "precision_ratio".  "adam" triggers the Adam optimiser on both backends.
+    # (learning_kind, lr, label) — lr is applied uniformly to all kinds.
+    # "adam" triggers the Adam optimiser on both backends.
     lr_variants = [
         ("precision_weighted", 0.1, "precision_weighted lr=0.1"),
         ("precision_weighted", "adam", "precision_weighted adam"),
         ("standard", 0.1, "standard lr=0.1"),
-        ("precision_ratio", 0.1, "precision_ratio lr=0.1"),
     ]
 
     for coupling_name, py_coupling_fn in coupling_variants:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -256,7 +256,7 @@ def test_learning():
 
     network.fit(x=x, y=y, inputs_x_idxs=(3,), inputs_y_idxs=(0, 1), lr=0.2)
 
-    # Kalman-gain learning rule with a fixed step size
+    # Precision-weighted learning rule with a fixed step size
     network = (
         Network(volatility_updates="unbounded")
         .add_nodes(n_nodes=2, precision=2.0, expected_precision=2.0)
@@ -274,7 +274,7 @@ def test_learning():
         inputs_x_idxs=(3,),
         inputs_y_idxs=(0, 1),
         lr=0.2,
-        learning_kind="precision_ratio",
+        learning_kind="precision_weighted",
     )
 
 


### PR DESCRIPTION
Replaces the five weight-gradient modes with two on a single axis: which geometry the update respects: `standard` (no metric), `precision_weighted` (the backprop-parity mode),. `precision_ratio`, `map_natural`, and `pure_natural` are removed.

Under high clipped precision the precision_weighted is the back-propagation parity. We still need to derive a local update using the natural gradient.

Every kind factorises into a child-side and a parent-side vector; `vectorized_weight_gradient_factors` exposes the two factors so a batched caller can average gradients over samples with one contraction instead of materialising a weight-matrix-sized gradient per sample.