### PR TITLE
Declarative DeepNetwork API, fused pipeline, and batch-synchronous sweeps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
           - --black                     # quote/blankline conventions match ruff-format
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.15.17
+  rev: v0.15.20
   hooks:
     # Run the linter.
     - id: ruff
@@ -24,7 +24,7 @@ repos:
     # Run the formatter.
     - id: ruff-format
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v2.1.0'
+    rev: 'v2.2.0'
     hooks:
     - id: mypy 
       files: ^pyhgf/

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -362,6 +362,7 @@ Vectorized learning
    :toctree: generated/pyhgf.updates.vectorized.learning
 
     vectorized_weight_gradient
+    vectorized_weight_gradient_factors
 
 Model
 *****
@@ -401,6 +402,75 @@ of a trained Equinox module, translating its weights into PyHGF's layer layout.
    from_linear
    from_feedforward
    from_embedding
+
+Declarative construction
+========================
+
+Build a :class:`~pyhgf.model.DeepNetwork` from serializable layer configurations, for
+configuration-driven experiments and reproducible hyperparameter sweeps.
+
+.. currentmodule:: pyhgf.model.builder
+
+.. autosummary::
+   :toctree: generated/pyhgf.model.builder
+   :nosignatures:
+
+   LayerConfig
+   resolve_coupling_fn
+
+Mixed pipelines
+===============
+
+Declare models as a tree of **parts** mixing learning PyHGF networks with frozen
+calculations. Each part translates prediction errors backward through the tree, so
+locally-learning networks and fixed operations compose into one model.
+
+.. currentmodule:: pyhgf.model.hybrid
+
+.. autosummary::
+   :toctree: generated/pyhgf.model.hybrid
+   :nosignatures:
+
+   PCModule
+   DeepNetworkAdapter
+   EquinoxAdapter
+   PCSequential
+   Residual
+   linear_adapter
+   layer_norm_adapter
+   gelu_adapter
+
+Transformer
+===========
+
+A GPT-style Transformer assembled from mixed-pipeline parts, where any slot can hold a
+frozen calculation or a learning PyHGF network.
+
+.. currentmodule:: pyhgf.model.transformer
+
+.. autosummary::
+   :toctree: generated/pyhgf.model.transformer
+   :nosignatures:
+
+   MultiHeadAttention
+   HybridGPT
+   hybrid_from_gpt
+
+Fused pipeline execution
+========================
+
+Run a part tree as a single compiled program per training step: the forward walk, the
+output error, and every local learning step are staged into one graph with all part
+state passed explicitly.
+
+.. currentmodule:: pyhgf.model.fused
+
+.. autosummary::
+   :toctree: generated/pyhgf.model.fused
+   :nosignatures:
+
+   FusedPipeline
+   step_report
 
 Plots
 *****
@@ -526,6 +596,15 @@ Scan-based belief propagation used internally by :class:`pyhgf.model.DeepNetwork
    propagation_step
    prediction_pass
    run_scan
+   prediction_sweep
+   update_sweep
+   learn_sweep
+   input_prediction_error
+   sample_step
+   batch_step
+   apply_confidence_increments
+   batched_prediction_pass
+   batched_prediction_states
 
 Math
 ****

--- a/pyhgf/model/__init__.py
+++ b/pyhgf/model/__init__.py
@@ -13,16 +13,44 @@ from .add_nodes import (
     insert_nodes,
     update_parameters,
 )
+from .builder import LayerConfig, resolve_coupling_fn
 from .deep_network import DeepNetwork
+from .fused import FusedPipeline, step_report
+from .hybrid import (
+    DeepNetworkAdapter,
+    EquinoxAdapter,
+    PCModule,
+    PCSequential,
+    Residual,
+    gelu_adapter,
+    layer_norm_adapter,
+    linear_adapter,
+)
 from .network import Network
+from .transformer import HybridGPT, MultiHeadAttention, hybrid_from_gpt
 from .transplant import from_embedding, from_feedforward, from_linear
 
 __all__ = [
     "Network",
     "DeepNetwork",
+    "LayerConfig",
+    "resolve_coupling_fn",
     "from_linear",
     "from_feedforward",
     "from_embedding",
+    "PCModule",
+    "EquinoxAdapter",
+    "DeepNetworkAdapter",
+    "PCSequential",
+    "Residual",
+    "gelu_adapter",
+    "layer_norm_adapter",
+    "linear_adapter",
+    "step_report",
+    "FusedPipeline",
+    "MultiHeadAttention",
+    "HybridGPT",
+    "hybrid_from_gpt",
     "LayerState",
     "LayerParams",
     "predict",

--- a/pyhgf/model/builder.py
+++ b/pyhgf/model/builder.py
@@ -1,0 +1,177 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+"""Configuration and factory functions for building DeepNetworks declaratively.
+
+Provides dataclasses and utilities for constructing networks from configuration
+dictionaries (e.g., JSON, YAML) or lists of layer configs, enabling reproducible
+hyperparameter sweeps, model zoos, and configuration-driven experiments.
+
+Example:
+    >>> from pyhgf.model import LayerConfig, DeepNetwork
+    >>> config = {
+    ...     "layers": [
+    ...         {"size": 10},
+    ...         {"size": 20, "coupling_fn": "gelu"},
+    ...         {"size": 15}
+    ...     ],
+    ...     "volatility_updates": "unbounded"
+    ... }
+    >>> net = DeepNetwork.from_dict(config)
+    >>> net.n_layers
+    3
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, fields
+from typing import Any, Callable, Optional
+
+import jax.nn
+
+
+@dataclass
+class LayerConfig:
+    """Configuration for one layer in a DeepNetwork.
+
+    Encapsulates all per-layer settings so they can be serialized to/from JSON, YAML,
+    or other formats. Each field corresponds to a parameter of
+    :meth:`DeepNetwork.add_layer`.
+
+    Attributes
+    ----------
+    size : int
+        Number of nodes in the layer.
+    kind : str, default "volatile"
+        Type of nodes: "volatile", "binary", or "categorical".
+    add_constant_input : bool, default True
+        Whether to add a bias term to the layer's predictions.
+    fully_connected : bool, default True
+        Whether the layer is fully connected (dense) or one-to-one.
+    coupling_fn : Optional[str], default None
+        Name of coupling function ("identity", "gelu", "relu", etc.) or None to use the
+        network-level default. Must be a name that can be resolved via
+        :func:`resolve_coupling_fn`.
+    volatility_parent : bool, default True
+        Whether the layer has an internal volatility parent.
+    tonic_volatility : Optional[float], default None
+        Per-layer override for tonic_volatility parameter.
+    tonic_volatility_vol : Optional[float], default None
+        Per-layer override for tonic_volatility_vol parameter.
+    volatility_coupling : Optional[float], default None
+        Per-layer override for volatility_coupling parameter.
+    autoconnection_strength_vol : Optional[float], default None
+        Per-layer override for autoconnection_strength_vol parameter.
+
+    Notes
+    -----
+    String coupling function names (e.g., "gelu", "relu") are resolved at network build
+    time. Use None to inherit the network-level coupling function.
+    """
+
+    size: int
+    kind: str = "volatile"
+    add_constant_input: bool = True
+    fully_connected: bool = True
+    coupling_fn: Optional[str] = None
+    volatility_parent: bool = True
+    tonic_volatility: Optional[float] = None
+    tonic_volatility_vol: Optional[float] = None
+    volatility_coupling: Optional[float] = None
+    autoconnection_strength_vol: Optional[float] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a JSON-serializable dictionary.
+
+        Excludes None values for cleaner configs. Use this when serializing to JSON or
+        YAML to avoid cluttering the output.
+
+        Returns
+        -------
+        dict[str, Any]
+            Dictionary with only non-None fields.
+        """
+        result = asdict(self)
+        return {k: v for k, v in result.items() if v is not None}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LayerConfig:
+        """Construct from a dictionary.
+
+        Provides flexibility: missing keys get their default values, and extra keys are
+        ignored (allowing extension without breaking).
+
+        Parameters
+        ----------
+        data : dict[str, Any]
+            Dictionary with layer configuration.
+
+        Returns
+        -------
+        LayerConfig
+            Configured layer.
+        """
+        # Keep only recognised fields; extra keys are ignored so configs can
+        # carry annotations without breaking construction.
+        valid_fields = {f.name for f in fields(cls)}
+        filtered = {k: v for k, v in data.items() if k in valid_fields}
+        return cls(**filtered)
+
+
+def resolve_coupling_fn(name_or_fn: Optional[str | Callable]) -> Optional[Callable]:
+    """Resolve a coupling function name to a callable.
+
+    Parameters
+    ----------
+    name_or_fn : Optional[str | Callable]
+        Either a string name ("gelu", "relu", "identity", etc.), a callable, or None
+        (returns None).
+
+    Returns
+    -------
+    Optional[Callable]
+        The resolved function, or None if input is None.
+
+    Raises
+    ------
+    ValueError
+        If the name is not recognized.
+
+    Examples
+    --------
+    >>> fn = resolve_coupling_fn("gelu")
+    >>> fn is jax.nn.gelu
+    True
+    >>> resolve_coupling_fn(None) is None
+    True
+    >>> resolve_coupling_fn(lambda x: x)  # Already callable
+    <function <lambda> at ...>
+    """
+    if name_or_fn is None:
+        return None
+
+    if callable(name_or_fn):
+        return name_or_fn
+
+    if isinstance(name_or_fn, str):
+        mapping = {
+            "identity": lambda x: x,
+            "gelu": jax.nn.gelu,
+            "relu": jax.nn.relu,
+            "tanh": jax.nn.tanh,
+            "sigmoid": jax.nn.sigmoid,
+            "elu": jax.nn.elu,
+            "silu": jax.nn.silu,
+            "swish": jax.nn.swish,
+        }
+        if name_or_fn not in mapping:
+            raise ValueError(
+                f"Unknown coupling function: '{name_or_fn}'. "
+                f"Valid names: {sorted(mapping.keys())}. "
+                f"Alternatively, pass a callable directly."
+            )
+        return mapping[name_or_fn]
+
+    raise TypeError(
+        f"coupling_fn must be None, a string name, or a callable; "
+        f"got {type(name_or_fn).__name__}"
+    )

--- a/pyhgf/model/deep_network.py
+++ b/pyhgf/model/deep_network.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import dataclasses
 import os
-from typing import Callable, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import equinox as eqx
 import jax
@@ -20,14 +20,26 @@ import numpy as np
 import optax
 import pandas as pd
 
+from pyhgf.model.builder import LayerConfig, resolve_coupling_fn
 from pyhgf.typing.vectorised import (
+    VOLATILITY_STATE_FIELDS,
     Layer,
     LayerParams,
     LayerState,
     Network,
     stack_layers,
 )
-from pyhgf.utils.vectorized_belief_propagation import prediction_pass, run_scan
+from pyhgf.utils.vectorized_belief_propagation import (
+    batch_step,
+    batched_prediction_pass,
+    batched_prediction_states,
+    input_prediction_error,
+    learn_sweep,
+    prediction_pass,
+    prediction_sweep,
+    run_scan,
+    update_sweep,
+)
 from pyhgf.utils.weight_initialisation import (
     he_init,
     orthogonal_init,
@@ -46,6 +58,10 @@ _LAYER_PARAM_DEFAULTS: dict[str, float] = {
 # Names of fields that can be overridden per layer (eqx.Modules expose dataclass fields).
 _LAYER_STATE_FIELDS: frozenset[str] = frozenset(LayerState.__dataclass_fields__.keys())
 _LAYER_PARAM_FIELDS: frozenset[str] = frozenset(LayerParams.__dataclass_fields__.keys())
+# Volatility-level state fields, absent (``None``) on a layer without a
+# volatility parent — a state override for one of these on such a layer is
+# dropped rather than re-allocating the array.
+_VOL_STATE_FIELDS: frozenset[str] = frozenset(VOLATILITY_STATE_FIELDS)
 
 # Minimum identical-layer count for ``add_layer_stack`` to auto-collapse the
 # block into a ``LayerStack`` (i.e. switch the propagation kernels to
@@ -162,6 +178,191 @@ class DeepNetwork:
         self._optimizer: Optional[optax.GradientTransformation] = None
         self.trajectories: Optional[Network] = None
         self.predictions: Optional[jnp.ndarray] = None
+        # Per-sample input-layer errors from the last batch_update call,
+        # shape (batch, n_input_features).
+        self.input_errors: Optional[jnp.ndarray] = None
+
+    @classmethod
+    def from_configs(
+        cls,
+        configs: list[LayerConfig],
+        coupling_fn: Optional[Callable | str] = None,
+        volatility_updates: str = "unbounded",
+        max_posterior_precision: float = 1e10,
+        precision_clipping_value: float = 1e-6,
+    ) -> "DeepNetwork":
+        """Build a network from a list of layer configurations.
+
+        Constructs a DeepNetwork by adding layers in order from a list of
+        :class:`LayerConfig` objects. This is useful for reproducible experiments,
+        hyperparameter sweeps, and programmatic model construction.
+
+        Parameters
+        ----------
+        configs : list[LayerConfig]
+            List of layer configurations, outermost (output) layer first.
+        coupling_fn : Optional[Callable | str], default None
+            Default coupling function applied between layers. Can be a callable
+            (e.g., ``jax.nn.gelu``) or a string name (e.g., ``"gelu"``).
+            Per-layer overrides in configs take precedence.
+        volatility_updates : str, default "unbounded"
+            The type of volatility-level posterior update.
+        max_posterior_precision : float, default 1e10
+            Upper bound applied to posterior precision writes.
+        precision_clipping_value : float, default 1e-6
+            Bound applied to binary-layer predicted means.
+
+        Returns
+        -------
+        DeepNetwork
+            Fully constructed network with all layers added.
+
+        Raises
+        ------
+        ValueError
+            If any layer config is invalid or a coupling function name
+            is not recognized.
+
+        Examples
+        --------
+        >>> from pyhgf.model import LayerConfig, DeepNetwork
+        >>> configs = [
+        ...     LayerConfig(size=10),
+        ...     LayerConfig(size=20, coupling_fn="gelu"),
+        ...     LayerConfig(size=15)
+        ... ]
+        >>> net = DeepNetwork.from_configs(configs)
+        >>> net.n_layers
+        3
+        """
+        if not configs:
+            raise ValueError("configs must not be empty")
+
+        # Resolve the network-level coupling function
+        net_coupling_fn = resolve_coupling_fn(coupling_fn)
+
+        # Create the network with the resolved coupling function
+        net = cls(
+            coupling_fn=net_coupling_fn or (lambda x: x),
+            volatility_updates=volatility_updates,
+            max_posterior_precision=max_posterior_precision,
+            precision_clipping_value=precision_clipping_value,
+        )
+
+        # Add layers in order
+        for config in configs:
+            # Resolve per-layer coupling function
+            layer_coupling_fn = resolve_coupling_fn(config.coupling_fn)
+            if layer_coupling_fn is None:
+                layer_coupling_fn = net_coupling_fn
+
+            # Prepare per-layer parameter overrides
+            overrides = {}
+            if config.tonic_volatility is not None:
+                overrides["tonic_volatility"] = config.tonic_volatility
+            if config.tonic_volatility_vol is not None:
+                overrides["tonic_volatility_vol"] = config.tonic_volatility_vol
+            if config.volatility_coupling is not None:
+                overrides["volatility_coupling"] = config.volatility_coupling
+            if config.autoconnection_strength_vol is not None:
+                overrides["autoconnection_strength_vol"] = (
+                    config.autoconnection_strength_vol
+                )
+
+            # Add the layer
+            net = net.add_layer(
+                size=config.size,
+                kind=config.kind,
+                add_constant_input=config.add_constant_input,
+                fully_connected=config.fully_connected,
+                coupling_fn=layer_coupling_fn,
+                volatility_parent=config.volatility_parent,
+                **overrides,
+            )
+
+        return net
+
+    @classmethod
+    def from_dict(
+        cls,
+        config: dict[str, Any],
+    ) -> "DeepNetwork":
+        """Build a network from a dictionary configuration.
+
+        Loads a network configuration from a dictionary (e.g., from JSON or YAML),
+        making it easy to version control and reproduce experiments.
+
+        Parameters
+        ----------
+        config : dict[str, Any]
+            Configuration dictionary with keys:
+            - "layers" (required): list of layer configs (each a dict or LayerConfig)
+            - "coupling_fn" (optional): default coupling function name or callable
+            - "volatility_updates" (optional): volatility update scheme
+            - "max_posterior_precision" (optional): precision upper bound
+            - "precision_clipping_value" (optional): binary-layer clipping bound
+
+        Returns
+        -------
+        DeepNetwork
+            Fully constructed network.
+
+        Raises
+        ------
+        ValueError
+            If "layers" is missing or invalid.
+        KeyError
+            If required layer fields are missing.
+
+        Examples
+        --------
+        >>> config = {
+        ...     "layers": [
+        ...         {"size": 10},
+        ...         {"size": 20, "coupling_fn": "gelu"},
+        ...         {"size": 15}
+        ...     ],
+        ...     "coupling_fn": "identity",
+        ...     "volatility_updates": "unbounded"
+        ... }
+        >>> net = DeepNetwork.from_dict(config)
+        >>> net.n_layers
+        3
+
+        You can also save and load from JSON:
+
+        >>> import json
+        >>> json_str = json.dumps(config)
+        >>> loaded_config = json.loads(json_str)
+        >>> net = DeepNetwork.from_dict(loaded_config)
+        """
+        if "layers" not in config:
+            raise ValueError("config must contain a 'layers' key")
+
+        # Convert layer dicts to LayerConfig objects
+        layers_data = config["layers"]
+        if not layers_data:
+            raise ValueError("'layers' must not be empty")
+
+        configs = [
+            LayerConfig.from_dict(layer) if isinstance(layer, dict) else layer
+            for layer in layers_data
+        ]
+
+        # Extract network-level parameters
+        net_config = {
+            k: v
+            for k, v in config.items()
+            if k
+            in (
+                "coupling_fn",
+                "volatility_updates",
+                "max_posterior_precision",
+                "precision_clipping_value",
+            )
+        }
+
+        return cls.from_configs(configs, **net_config)
 
     def add_layer(
         self,
@@ -238,6 +439,14 @@ class DeepNetwork:
         if kind not in valid_kinds:
             raise ValueError(
                 f"Invalid layer kind '{kind}'. Choose from {sorted(valid_kinds)}."
+            )
+        if kind == "categorical" and self.layer_sizes:
+            # A softmax couples every node of the layer into one choice; that
+            # is only meaningful for the observed (bottom) layer, where the
+            # one-hot truth is clamped.
+            raise ValueError(
+                "Categorical layers represent a single N-way choice and are "
+                "only supported as the output (bottom) layer — add it first."
             )
 
         invalid_keys = [k for k in kwargs if k not in _LAYER_OVERRIDE_FIELDS]
@@ -360,12 +569,16 @@ class DeepNetwork:
         for i, size in enumerate(self.layer_sizes):
             overrides = self.layer_overrides[i]
 
-            # Per-layer state with overrides (broadcast scalar -> (n_nodes,))
-            state = LayerState.create(size)
+            # Per-layer state with overrides (broadcast scalar -> (n_nodes,)).
+            # Without a volatility parent the volatility fields are ``None``; a
+            # state override for one of them is dropped, since the frozen
+            # volatility level never reads it.
+            has_vol = self.volatility_parents[i]
+            state = LayerState.create(size, has_volatility_parent=has_vol)
             state_overrides = {
                 k: jnp.full(size, v)
                 for k, v in overrides.items()
-                if k in _LAYER_STATE_FIELDS
+                if k in _LAYER_STATE_FIELDS and (has_vol or k not in _VOL_STATE_FIELDS)
             }
             if state_overrides:
                 state = dataclasses.replace(state, **state_overrides)
@@ -632,7 +845,241 @@ class DeepNetwork:
         # Handle single sample vs batch.
         if x.ndim == 1:
             return prediction_pass(self.state, x)
-        return jax.vmap(lambda xi: prediction_pass(self.state, xi))(x)
+        return batched_prediction_pass(self.state, x)
+
+    def prediction(self, x: Union[np.ndarray, jnp.ndarray]) -> "DeepNetwork":
+        """Run the top-down prediction sweep only.
+
+        Clamps the predictors ``x`` on the input (top) layer, predicts every layer
+        from the one above, and writes the resulting beliefs back to ``self.state``.
+        No prediction errors, posterior updates, or weight learning are performed —
+        use :meth:`update` for the bottom-up belief update and :meth:`fit` for weight
+        learning.
+
+        Unlike :meth:`predict` (which returns the bottom layer's ``expected_mean`` and
+        leaves the network untouched), this advances and stores the network state, so
+        a subsequent :meth:`update` sees the predicted beliefs.
+
+        Parameters
+        ----------
+        x :
+            Predictors clamped on the top layer, shape ``(n_input_features,)``. Single
+            sample only; use :meth:`predict` for a batched, read-only forward pass.
+
+        Returns
+        -------
+        DeepNetwork
+            Self, with ``self.state`` advanced by the prediction sweep.
+        """
+        if self.state is None:
+            raise ValueError("Add at least one layer before calling prediction.")
+        x = jnp.asarray(x)
+        if x.ndim != 1:
+            raise ValueError(
+                "prediction() operates on a single sample (1D x); "
+                "use predict() for a batched read-only forward pass."
+            )
+        self.state = prediction_sweep(self.state, x)
+        return self
+
+    def update(
+        self,
+        y: Union[np.ndarray, jnp.ndarray],
+        optimizer: Optional[optax.GradientTransformation] = None,
+        learning_kind: str = "precision_weighted",
+    ) -> "DeepNetwork":
+        """Run the bottom-up prediction-error + posterior-update sweep.
+
+        Clamps the observations ``y`` on the output (bottom) layer, computes the leaf
+        prediction error, then performs the interleaved posterior-update + prediction-
+        error for every interior layer, in the correct bottom-up order. Belief states
+        (means and precisions) are always updated.
+
+        If an ``optimizer`` is supplied, a weight-learning phase runs *after* the belief
+        sweep: PE-driven gradients are formed and applied to every inter-layer weight
+        matrix, with the optimiser state held on ``self.opt_state``. With
+        ``optimizer=None`` (default) the weights are left unchanged, exactly as
+        :meth:`fit` would leave them with ``weight_update=False``.
+
+        Typically called right after :meth:`prediction`, which sets up the predicted
+        beliefs this sweep corrects, so a full local learning step without backprop is::
+
+            net.prediction(x).update(y, optimizer=optax.sgd(1e-2))
+
+        Parameters
+        ----------
+        y :
+            Observations clamped on the bottom layer, shape ``(n_output_features,)``.
+            Single sample only.
+        optimizer :
+            Optional ``optax.GradientTransformation``. If given, run the weight-learning
+            phase and update ``self.opt_state``. If ``None``, only beliefs are updated.
+        learning_kind :
+            Weight-gradient mode used when ``optimizer`` is supplied. One of
+            ``"standard"`` or ``"precision_weighted"`` (default). Both are
+            strictly local. Each weight update reads only its own
+            connection's prediction error, activation, and precision.
+
+        Returns
+        -------
+        DeepNetwork
+            Self, with ``self.state`` (and, if learning, ``self.opt_state``) advanced.
+        """
+        if self.state is None:
+            raise ValueError("Add at least one layer before calling update.")
+        y = jnp.asarray(y)
+        if y.ndim != 1:
+            raise ValueError("update() operates on a single sample (1D y).")
+        self.state = update_sweep(self.state, y)
+
+        if optimizer is not None:
+            # Initialise opt_state on first use, or when the optimiser changes.
+            if self.opt_state is None or self._optimizer is not optimizer:
+                self.opt_state = optimizer.init(self.state.weights_tuple())
+                self._optimizer = optimizer
+            self.state, self.opt_state = learn_sweep(
+                self.state, self.opt_state, optimizer, learning_kind
+            )
+        return self
+
+    def input_error(self) -> jnp.ndarray:
+        """Prediction error at the input (top) layer.
+
+        The bottom-up sweep leaves the top layer untouched (its values are
+        clamped to the predictors), so this is the only way to read the error
+        message the input would receive from the layer below — the child
+        layer's prediction error, weighted by its confidence (precision) and
+        routed back through the connecting weights. Typical usage runs the
+        two sweeps first::
+
+            net.prediction(x).update(y)
+            error_at_input = net.input_error()
+
+        Because prediction errors follow the ``observed - predicted``
+        convention, the result is the negative of the gradient of a
+        squared-error loss with respect to the predictors.
+
+        Returns
+        -------
+        jnp.ndarray
+            The prediction error at the top layer, shape
+            ``(n_input_features,)``.
+        """
+        if self.state is None:
+            raise ValueError("Add at least one layer before calling input_error.")
+        return input_prediction_error(self.state)
+
+    def predict_states(
+        self, x: Union[np.ndarray, jnp.ndarray]
+    ) -> tuple[jnp.ndarray, tuple]:
+        """Batched forward pass that also returns the per-sample swept states.
+
+        Returns the same predictions as :meth:`predict` on 2D input, plus the
+        per-sample layer states the sweep computed. Passing those states to
+        :meth:`batch_update` (as ``predicted``) skips its internal forward
+        sweep, so a caller that has already predicted does not pay for the
+        sweep twice.
+
+        Parameters
+        ----------
+        x :
+            Predictors, shape ``(batch, n_input_features)``.
+
+        Returns
+        -------
+        predictions :
+            Shape ``(batch, n_output_features)``.
+        states :
+            One batched ``LayerState`` per element — an opaque value to hand
+            back to :meth:`batch_update`.
+        """
+        if self.state is None:
+            raise ValueError("Add at least one layer before calling predict_states.")
+        states = batched_prediction_states(self.state, jnp.asarray(x))
+        return states[0].expected_mean, states
+
+    def batch_update(
+        self,
+        x: Union[np.ndarray, jnp.ndarray],
+        y: Union[np.ndarray, jnp.ndarray],
+        optimizer: Optional[optax.GradientTransformation] = None,
+        learning_kind: str = "precision_weighted",
+        update_confidences: bool = True,
+        time_step: float = 1.0,
+        predicted: Optional[tuple] = None,
+    ) -> "DeepNetwork":
+        """One batch-synchronous learning step over many samples at once.
+
+        Every sample in the batch is processed from the same state — same
+        weights, same confidences — in parallel; the per-sample weight
+        gradients and confidence changes are then *averaged* and applied
+        once, so the whole batch counts as a single observation. This
+        differs from :meth:`fit`, which scans samples sequentially and lets
+        the confidences adapt from one sample to the next (the natural mode
+        for a time series). Use this method when samples are exchangeable —
+        e.g. many token positions learned together.
+
+        The per-sample errors at the input layer are stored on
+        ``self.input_errors``, shape ``(batch, n_input_features)`` — see
+        :meth:`input_error` for their meaning and sign convention.
+
+        Parameters
+        ----------
+        x :
+            Predictors, shape ``(batch, n_input_features)``.
+        y :
+            Observations, shape ``(batch, n_output_features)``.
+        optimizer :
+            Optax optimiser for the weight step. ``None`` (default) freezes
+            the weights.
+        learning_kind :
+            Weight-gradient mode, as in :meth:`fit`.
+        update_confidences :
+            If True (default), carry the batch-averaged change of the
+            confidence state (value-level precisions and the volatility
+            level) into ``self.state``. Set to False to keep confidences
+            pinned, e.g. for exact comparisons against backpropagation.
+        time_step :
+            Inference time step, applied once per batch.
+        predicted :
+            Optional per-sample predicted states from :meth:`predict_states`;
+            when given, the internal forward sweep is skipped and ``x`` is
+            ignored.
+
+        Returns
+        -------
+        DeepNetwork
+            Self, with ``self.state`` (and, if learning, ``self.opt_state``)
+            advanced by one batch.
+        """
+        if self.state is None:
+            raise ValueError("Add at least one layer before calling batch_update.")
+        x = jnp.asarray(x)
+        y = jnp.asarray(y)
+        if x.ndim != 2 or y.ndim != 2:
+            raise ValueError(
+                "batch_update() operates on batches: x and y must be 2D "
+                "(batch, n_features)."
+            )
+
+        if optimizer is not None and (
+            self.opt_state is None or self._optimizer is not optimizer
+        ):
+            self.opt_state = optimizer.init(self.state.weights_tuple())
+            self._optimizer = optimizer
+
+        self.state, self.opt_state, self.input_errors = batch_step(
+            self.state,
+            self.opt_state,
+            x,
+            y,
+            optimizer=optimizer,
+            learning_kind=learning_kind,
+            update_confidences=update_confidences,
+            time_step=float(time_step),
+            predicted=predicted,
+        )
+        return self
 
     def reset(self) -> "DeepNetwork":
         """Reset the network state."""

--- a/pyhgf/model/fused.py
+++ b/pyhgf/model/fused.py
@@ -1,0 +1,499 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+"""The pipeline executor: one compiled program per training step.
+
+The classes in :mod:`pyhgf.model.hybrid` and :mod:`pyhgf.model.transformer` *declare* a
+model — which slots learn, which are frozen, how parts nest. :class:`FusedPipeline`
+runs such a part tree: every part's state (network beliefs, weights, optimiser
+moments) enters and leaves as explicit values, and the forward walk, the error at the
+output, and every local learning step are staged into a single compiled program —
+nothing crosses a compilation boundary inside one training step.
+
+See ``docs/source/notebooks/0.6-Deep_networks_implementation.md`` for the architecture guide and the
+verification gates.
+
+Supported part trees: :class:`~pyhgf.model.hybrid.DeepNetworkAdapter`,
+:class:`~pyhgf.model.hybrid.EquinoxAdapter`, :class:`~pyhgf.model.hybrid.PCSequential`,
+:class:`~pyhgf.model.hybrid.Residual`,
+:class:`~pyhgf.model.transformer.MultiHeadAttention`, and the assembled
+:class:`~pyhgf.model.transformer.HybridGPT` — the entire Transformer trains in one
+compiled call per step.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, NamedTuple, Optional
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+
+from pyhgf.model.hybrid import (
+    DeepNetworkAdapter,
+    EquinoxAdapter,
+    PCSequential,
+    Residual,
+)
+from pyhgf.model.transformer import (
+    HybridGPT,
+    MultiHeadAttention,
+    _mixing_backward,
+    _mixing_forward,
+)
+from pyhgf.utils.vectorized_belief_propagation import (
+    _batch_step,
+    _prediction_sweep,
+)
+
+__all__ = ["FusedPipeline", "step_report"]
+
+
+class _Core(NamedTuple):
+    """A part tree's training step as pure functions with explicit state.
+
+    ``forward(state, x)`` returns the tree's output and a cache of whatever the backward
+    walk needs; ``backward(state, cache, error)`` returns the error at the tree's input,
+    the advanced state, and a tuple of per-part report entries (see
+    :func:`step_report`). All are pure — the recursion over the tree happens while
+    tracing, staging one graph. ``write_back(state)`` copies a state pytree onto the
+    part objects the core was built from.
+    """
+
+    init_state: Any
+    forward: Callable[[Any, jnp.ndarray], tuple[jnp.ndarray, Any]]
+    backward: Callable[[Any, Any, jnp.ndarray], tuple[jnp.ndarray, Any, tuple]]
+    write_back: Callable[[Any], None]
+
+
+def _adapter_core(part: DeepNetworkAdapter, path: str) -> _Core:
+    """Build the core of a learning part: sweep forward, batch learning backward.
+
+    The state is the pair (network, optimiser state). The forward pass keeps the per-
+    sample swept states as the cache, so the backward pass starts from them instead of
+    re-running the sweep — inside one trace, the handover is free.
+    """
+    optimizer = part.optimizer
+    learning_kind = part.learning_kind
+    update_confidences = part.update_confidences
+    time_step = part.time_step
+    layer_sizes = list(part.net.layer_sizes)
+
+    # part.init_state() returns the (network, opt_state) pytree directly.
+    init_state_pytree = part.init_state()
+
+    def forward(state, x):
+        network, _ = state
+        flat = x.reshape(-1, x.shape[-1])
+
+        def one(xi):
+            swept = _prediction_sweep(network, xi, time_step=time_step)
+            return tuple(elem.state for elem in swept.layers)
+
+        states = jax.vmap(one)(flat)
+        out = states[0].expected_mean
+        return out.reshape(*x.shape[:-1], -1), (flat, states)
+
+    def backward(state, cache, error):
+        network, opt_state = state
+        flat_x, states = cache
+        out = states[0].expected_mean
+        weights_before = network.weights_tuple()
+        # Correct-and-clamp: the observation the network should have
+        # produced is its output corrected by the error.
+        network, opt_state, input_errors = _batch_step(
+            network,
+            opt_state,
+            flat_x,
+            out - error.reshape(-1, error.shape[-1]),
+            optimizer=optimizer,
+            learning_kind=learning_kind,
+            update_confidences=update_confidences,
+            time_step=time_step,
+            predicted=states,
+        )
+        update_norm = jnp.sqrt(
+            sum(
+                jnp.sum((after - before) ** 2)
+                for before, after in zip(weights_before, network.weights_tuple())
+                if after is not None
+            )
+        )
+        report = (
+            {
+                "part": path,
+                "layer_sizes": layer_sizes,
+                "update_norm": update_norm,
+                "error_norm": jnp.linalg.norm(error),
+            },
+        )
+        # PyHGF's input errors are observed-minus-predicted; the pipeline
+        # convention is descent.
+        return (
+            -input_errors.reshape(*error.shape[:-1], -1),
+            (network, opt_state),
+            report,
+        )
+
+    def write_back(state):
+        part.net.state, part.net.opt_state = state
+
+    return _Core(init_state_pytree, forward, backward, write_back)
+
+
+def _frozen_core(part: EquinoxAdapter, path: str) -> _Core:
+    """Build the core of a frozen part: its formula pair, cache threaded explicitly.
+
+    A frozen part has no learnable state, so its state pytree is empty.
+    """
+    init_state_pytree = ()
+
+    def forward(state, x):
+        return part.forward_fn(x)
+
+    def backward(state, cache, error):
+        return part.backward_fn(cache, error), state, ()
+
+    return _Core(init_state_pytree, forward, backward, lambda state: None)
+
+
+def _sequential_core(part: PCSequential, path: str) -> _Core:
+    """Build the core of a chain: children forward in order, backward in reverse.
+
+    The state is a tuple of the children's states, built from the child cores.
+    """
+    cores = [_core(child, f"{path}.parts[{i}]") for i, child in enumerate(part.parts)]
+
+    init_state_pytree = tuple(core.init_state for core in cores)
+
+    def forward(state, x):
+        caches = []
+        for core, child_state in zip(cores, state):
+            x, cache = core.forward(child_state, x)
+            caches.append(cache)
+        return x, tuple(caches)
+
+    def backward(state, caches, error):
+        new_state = list(state)
+        reports: list = []
+        for i in reversed(range(len(cores))):
+            error, new_state[i], report = cores[i].backward(state[i], caches[i], error)
+            reports[:0] = report  # keep pipeline order, not visit order
+        return error, tuple(new_state), tuple(reports)
+
+    def write_back(state):
+        for core, child_state in zip(cores, state):
+            core.write_back(child_state)
+
+    return _Core(init_state_pytree, forward, backward, write_back)
+
+
+def _residual_core(part: Residual, path: str) -> _Core:
+    """Build the core of the shortcut junction: the branch's messages add back.
+
+    State is obtained from the branch via its _Core's init_state pytree. The shortcut
+    itself has no state (it just routes signals), so the pytree is just the branch's
+    state.
+    """
+    inner = _core(part.branch, f"{path}.branch")
+
+    def forward(state, x):
+        y, cache = inner.forward(state, x)
+        return x + y, cache
+
+    def backward(state, cache, error):
+        error_in, new_state, report = inner.backward(state, cache, error)
+        return error + error_in, new_state, report
+
+    return _Core(inner.init_state, forward, backward, inner.write_back)
+
+
+def _attention_core(part: MultiHeadAttention, path: str) -> _Core:
+    """Build the core of the attention composite: Q/K/V, the mixing, then O.
+
+    Backward, the output error returns through O, is re-routed across positions by the
+    mixing formula, and the three resulting messages return through Q, K, and V — whose
+    input errors add, since all three read the same input.
+
+    State is obtained from each of the four weight table cores (Q, K, V, O), which have
+    already been initialized via their respective ``init_state()`` calls during _core
+    construction.
+    """
+    q_core, k_core, v_core, o_core = (
+        _core(child, f"{path}.{name}")
+        for name, child in (
+            ("wq", part.wq),
+            ("wk", part.wk),
+            ("wv", part.wv),
+            ("wo", part.wo),
+        )
+    )
+    n_heads = part.n_heads
+
+    # Aggregate init_state pytrees from all four cores.
+    init_state_pytree = tuple(
+        core.init_state for core in (q_core, k_core, v_core, o_core)
+    )
+
+    def forward(state, x):
+        state_q, state_k, state_v, state_o = state
+        q, cache_q = q_core.forward(state_q, x)
+        k, cache_k = k_core.forward(state_k, x)
+        v, cache_v = v_core.forward(state_v, x)
+        ctx, cache_mix = _mixing_forward(q, k, v, n_heads)
+        y, cache_o = o_core.forward(state_o, ctx)
+        return y, (cache_q, cache_k, cache_v, cache_mix, cache_o)
+
+    def backward(state, cache, error):
+        state_q, state_k, state_v, state_o = state
+        cache_q, cache_k, cache_v, cache_mix, cache_o = cache
+        d_ctx, new_o, report_o = o_core.backward(state_o, cache_o, error)
+        d_q, d_k, d_v = _mixing_backward(cache_mix, d_ctx)
+        error_q, new_q, report_q = q_core.backward(state_q, cache_q, d_q)
+        error_k, new_k, report_k = k_core.backward(state_k, cache_k, d_k)
+        error_v, new_v, report_v = v_core.backward(state_v, cache_v, d_v)
+        return (
+            error_q + error_k + error_v,
+            (new_q, new_k, new_v, new_o),
+            report_q + report_k + report_v + report_o,
+        )
+
+    def write_back(state):
+        for core, child_state in zip((q_core, k_core, v_core, o_core), state):
+            core.write_back(child_state)
+
+    return _Core(init_state_pytree, forward, backward, write_back)
+
+
+def _gpt_core(part: HybridGPT, path: str) -> _Core:
+    """Build the core of the full Transformer: embeddings, blocks, and head.
+
+    The forward pass takes integer token ids, not feature arrays: the one-hot encoding
+    (or the frozen table lookup) happens in-trace. Backward, the error at the embedding
+    output goes to both embedding parts — the position part receives the batch mean,
+    matching its one-row-per-position sample count — and is returned, ending the chain.
+
+    State is obtained from the pipeline and optional embedding parts via their
+    respective _Core init_state pytrees. Frozen embeddings contribute empty states.
+    """
+    pipeline_core = _core(part.pipeline, f"{path}.pipeline")
+    token_core = (
+        None
+        if part.token_part is None
+        else _core(part.token_part, f"{path}.token_part")
+    )
+    position_core = (
+        None
+        if part.position_part is None
+        else _core(part.position_part, f"{path}.position_part")
+    )
+    tok_table, pos_table = part.tok_table, part.pos_table
+
+    # Aggregate init_state pytrees: pipeline (always present) and optional
+    # token/position cores (empty tuples if frozen).
+    init_state_pytree = (
+        pipeline_core.init_state,
+        () if token_core is None else token_core.init_state,
+        () if position_core is None else position_core.init_state,
+    )
+
+    def forward(state, ids):
+        state_pipe, state_tok, state_pos = state
+        seq_len = ids.shape[1]
+        if token_core is not None:
+            tok, cache_tok = token_core.forward(
+                state_tok, jax.nn.one_hot(ids, tok_table.shape[0])
+            )
+        else:
+            tok, cache_tok = tok_table[ids], ()
+        if position_core is not None:
+            pos, cache_pos = position_core.forward(
+                state_pos, jax.nn.one_hot(jnp.arange(seq_len), pos_table.shape[0])
+            )
+        else:
+            pos, cache_pos = pos_table[:seq_len], ()
+        out, cache_pipe = pipeline_core.forward(state_pipe, tok + pos[None])
+        return out, (cache_pipe, cache_tok, cache_pos)
+
+    def backward(state, cache, error):
+        state_pipe, state_tok, state_pos = state
+        cache_pipe, cache_tok, cache_pos = cache
+        embedding_error, new_pipe, reports = pipeline_core.backward(
+            state_pipe, cache_pipe, error
+        )
+        new_tok, new_pos = state_tok, state_pos
+        if token_core is not None:
+            _, new_tok, report = token_core.backward(
+                state_tok, cache_tok, embedding_error
+            )
+            reports = reports + report
+        if position_core is not None:
+            _, new_pos, report = position_core.backward(
+                state_pos, cache_pos, embedding_error.mean(axis=0)
+            )
+            reports = reports + report
+        return embedding_error, (new_pipe, new_tok, new_pos), reports
+
+    def write_back(state):
+        state_pipe, state_tok, state_pos = state
+        pipeline_core.write_back(state_pipe)
+        if token_core is not None:
+            token_core.write_back(state_tok)
+        if position_core is not None:
+            position_core.write_back(state_pos)
+
+    return _Core(init_state_pytree, forward, backward, write_back)
+
+
+def _core(part, path: Optional[str] = None) -> _Core:
+    """Build the functional core for a part tree, by its type."""
+    if path is None:
+        path = type(part).__name__
+    if isinstance(part, DeepNetworkAdapter):
+        return _adapter_core(part, path)
+    if isinstance(part, EquinoxAdapter):
+        return _frozen_core(part, path)
+    if isinstance(part, PCSequential):
+        return _sequential_core(part, path)
+    if isinstance(part, Residual):
+        return _residual_core(part, path)
+    if isinstance(part, MultiHeadAttention):
+        return _attention_core(part, path)
+    if isinstance(part, HybridGPT):
+        return _gpt_core(part, path)
+    raise NotImplementedError(
+        "FusedPipeline supports DeepNetworkAdapter, EquinoxAdapter, "
+        "PCSequential, Residual, MultiHeadAttention, and HybridGPT trees; "
+        f"got {type(part).__name__}."
+    )
+
+
+class FusedPipeline:
+    """Run a part tree, one compiled program per training step.
+
+    Holds every part's mutable state (the network beliefs and weights, the optimiser
+    states) as one explicit pytree, and compiles a single step function: forward walk →
+    error at the output → backward walk with every local learning step → error at the
+    input. The error is formed *inside* the program by ``error_fn``, so no intermediate
+    crosses a compilation boundary.
+
+    The part objects only declare the model; they are not advanced while the executor
+    runs. Call :meth:`merge` to write the current state back onto them (e.g. to inspect
+    a network's layers, or to save it).
+
+    Parameters
+    ----------
+    part :
+        The part tree to execute: any composition of
+        :class:`~pyhgf.model.hybrid.DeepNetworkAdapter`,
+        :class:`~pyhgf.model.hybrid.EquinoxAdapter`,
+        :class:`~pyhgf.model.hybrid.PCSequential`,
+        :class:`~pyhgf.model.hybrid.Residual`, and
+        :class:`~pyhgf.model.transformer.MultiHeadAttention`, or a full
+        :class:`~pyhgf.model.transformer.HybridGPT` (whose inputs are then
+        integer token ids).
+    error_fn :
+        How the descent error at the tree's output is formed from the output and the
+        training target, e.g. ``lambda out, target: out - target`` for a squared-error
+        objective (the default), or
+        ``lambda probs, ids: probs - jax.nn.one_hot(ids, vocab)`` for a categorical
+        head trained on integer targets. Must be a pure function of arrays.
+    """
+
+    def __init__(
+        self,
+        part,
+        error_fn: Optional[Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]] = None,
+    ):
+        if error_fn is None:
+            error_fn = lambda out, target: out - target  # noqa: E731
+        self._part = part
+        self._core_fns = _core(part)
+        self.state = self._core_fns.init_state
+        self._last_report: Optional[tuple] = None
+
+        def step(state, x, target):
+            output, cache = self._core_fns.forward(state, x)
+            error = error_fn(output, target)
+            input_error, state, reports = self._core_fns.backward(state, cache, error)
+            return state, output, input_error, reports
+
+        self._step = eqx.filter_jit(step)
+        self._predict = eqx.filter_jit(
+            lambda state, x: self._core_fns.forward(state, x)[0]
+        )
+
+    def predict(self, x: jnp.ndarray) -> jnp.ndarray:
+        """Run the forward pass only — no error, no learning, no state change.
+
+        Use for evaluation and generation. For a
+        :class:`~pyhgf.model.transformer.HybridGPT`, ``x`` is a batch of integer token-
+        id sequences.
+        """
+        return self._predict(self.state, jnp.asarray(x))
+
+    def step(
+        self, x: jnp.ndarray, target: jnp.ndarray
+    ) -> tuple[jnp.ndarray, jnp.ndarray]:
+        """Advance the held state by one training step, in one compiled call.
+
+        Parameters
+        ----------
+        x :
+            Inputs, shape ``(batch, n_input_features)`` — or integer token ids,
+            ``(batch, seq)``, for a full Transformer.
+        target :
+            Training targets, shaped as ``error_fn`` expects alongside the tree's
+            output.
+
+        Returns
+        -------
+        output :
+            The tree's predictions for ``x``, shape ``(batch, n_output_features)``.
+        input_error :
+            The descent error at the tree's input — what a part behind the tree
+            would receive.
+        """
+        self.state, output, input_error, self._last_report = self._step(
+            self.state, jnp.asarray(x), jnp.asarray(target)
+        )
+        return output, input_error
+
+    def merge(self):
+        """Write the held state back onto the wrapped parts; return the tree."""
+        self._core_fns.write_back(self.state)
+        return self._part
+
+
+def step_report(pipeline: FusedPipeline) -> list:
+    """Per-part step magnitudes after a training step, for rate calibration.
+
+    Returns one entry per learning part of the last :meth:`FusedPipeline.step`
+    call: the norm of its applied weight change and of the error it received,
+    labelled by the part's path inside the model. Reading the two side by side
+    shows at a glance which parts are being over- or under-driven — the
+    practical symptom of a mis-calibrated learning rate (see the architecture
+    guide on choosing the optimizer and rate).
+
+    Parameters
+    ----------
+    pipeline :
+        The executor to read. Its part tree must have taken at least one step.
+
+    Returns
+    -------
+    list of dict
+        One entry per learning part, in pipeline order, with keys ``"part"``
+        (its path inside the model), ``"layer_sizes"`` (the wrapped network's
+        layout), ``"update_norm"`` and ``"error_norm"``.
+    """
+    if pipeline._last_report is None:
+        return []
+    return [
+        {
+            "part": entry["part"],
+            "layer_sizes": entry["layer_sizes"],
+            "update_norm": float(entry["update_norm"]),
+            "error_norm": float(entry["error_norm"]),
+        }
+        for entry in pipeline._last_report
+    ]

--- a/pyhgf/model/hybrid.py
+++ b/pyhgf/model/hybrid.py
@@ -1,0 +1,338 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+"""Mixed pipelines: declaring models that mix PyHGF networks and fixed calculations.
+
+A pipeline is a tree of **parts**. Each part either learns — a
+:class:`DeepNetworkAdapter` wrapping a PyHGF :class:`~pyhgf.model.DeepNetwork`, which
+learns locally through PyHGF's belief updates — or is frozen — an
+:class:`EquinoxAdapter` wrapping a fixed calculation (an activation function, a
+normalisation) that never learns and only translates errors with a hand-derived formula.
+:class:`PCSequential` chains parts; :class:`Residual` declares the "add back the input"
+shortcut.
+
+The classes here *declare* the model: which slots learn, what configuration each
+learning part uses, which formulas the frozen parts apply. Execution is the job of
+:class:`~pyhgf.model.fused.FusedPipeline`, which stages the whole tree — forward walk,
+error at the output, every part's local learning step — into one compiled program per
+training step. Walked forward, the tree predicts; walked backward, each part learns from
+the error at its output and hands the error at its *input* to the part behind it.
+Nothing resembling backpropagation runs anywhere: no global computation graph, no
+automatic differentiation.
+
+Error convention: the arrays passed between parts are *descent* errors — the gradient of
+the loss with respect to that signal, the same object a backprop library would hand
+around. PyHGF's internal prediction errors follow the opposite, observed-minus-predicted
+convention; the executor converts between the two at the learning part's boundary, in
+exactly one place.
+
+All parts operate on batches: arrays of shape ``(n_samples, n_features)``, one row per
+sample (e.g. one row per token position, flattened across sequences).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import optax
+
+from pyhgf.model.deep_network import DeepNetwork
+
+__all__ = [
+    "PCModule",
+    "EquinoxAdapter",
+    "DeepNetworkAdapter",
+    "PCSequential",
+    "Residual",
+    "gelu_adapter",
+    "layer_norm_adapter",
+    "linear_adapter",
+]
+
+
+class PCModule:
+    """Base class for all parts in a mixed pipeline.
+
+    A part contributes two core responsibilities to a mixed training pipeline:
+
+    1. **Declaration:** The part object (this class and its subclasses) declares
+       which computations learn and which are frozen, along with their
+       configuration (optimizer, layer sizes, activation functions, etc.).
+
+    2. **State management:** Each part declares its state structure via
+       :meth:`init_state`, which returns the state pytree this part holds
+       (network beliefs, optimizer moments, etc.). Execution is delegated to
+       :class:`~pyhgf.model.fused.FusedPipeline`.
+
+    All subclasses **must** implement:
+
+    - ``__init__(...)``: Store part configuration (layer sizes, optimizer, etc.)
+    - ``init_state()``: Return this part's state pytree
+
+    The executor (:class:`~pyhgf.model.fused.FusedPipeline`) calls ``init_state()``
+    to initialize the part's state, threads it through forward/backward walks in
+    one compiled JAX program, and writes it back via a ``merge()`` closure.
+
+    Notes
+    -----
+    Subclasses that do not define both ``__init__`` and ``init_state`` raise a
+    :class:`TypeError` at class definition time. See :class:`DeepNetworkAdapter`,
+    :class:`EquinoxAdapter`, :class:`PCSequential`, and :class:`Residual` for examples.
+    """
+
+    def __init_subclass__(cls, **kwargs):
+        """Require concrete parts to define ``__init__`` and ``init_state``.
+
+        Checked at class definition time so an incomplete part fails early with a
+        clear message rather than cryptically during training.
+
+        Raises
+        ------
+        TypeError
+            If the subclass defines neither ``__init__`` nor ``init_state``.
+        """
+        super().__init_subclass__(**kwargs)
+        if "__init__" not in cls.__dict__:
+            raise TypeError(
+                f"{cls.__name__} must define __init__() to declare part configuration."
+            )
+        # init_state must be overridden somewhere below PCModule's stub.
+        if not any(
+            "init_state" in base.__dict__
+            for base in cls.__mro__
+            if base is not PCModule
+        ):
+            raise TypeError(
+                f"{cls.__name__} must define init_state() returning its state pytree."
+            )
+
+    def init_state(self) -> Any:
+        """Initialize and return this part's state pytree.
+
+        Called by :class:`~pyhgf.model.fused.FusedPipeline` during setup to
+        build the full state pytree that is threaded through every training step:
+
+        - **Frozen parts** (:class:`EquinoxAdapter`): the empty tuple ``()``.
+        - **Learning parts** (:class:`DeepNetworkAdapter`): ``(network, opt_state)``.
+        - **Composite parts** (:class:`PCSequential`, :class:`Residual`, …): the
+          nested tuple of their children's states.
+
+        Raises
+        ------
+        NotImplementedError
+            If called on a subclass that does not override this method.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.init_state() must return its state pytree. "
+            f"See {PCModule.__name__} docstring for the per-part conventions."
+        )
+
+
+class EquinoxAdapter(PCModule):
+    """A frozen part: a fixed calculation that routes errors but never learns.
+
+    Declares a forward function and its hand-derived backward companion — no
+    automatic differentiation is involved at any point:
+
+    - ``forward_fn(x) -> (y, cache)`` computes the output for a batch and
+      returns whatever the backward formula needs;
+    - ``backward_fn(cache, error) -> error_in`` translates the error at the
+      output into the error at the input, using only the cache.
+
+    Use the ready-made constructors :func:`gelu_adapter` and
+    :func:`layer_norm_adapter` for the standard Transformer pieces.
+    """
+
+    def __init__(
+        self,
+        forward_fn: Callable[[jnp.ndarray], tuple[jnp.ndarray, tuple]],
+        backward_fn: Callable[[tuple, jnp.ndarray], jnp.ndarray],
+    ):
+        self.forward_fn = forward_fn
+        self.backward_fn = backward_fn
+
+    def init_state(self) -> tuple:
+        """Return the empty state pytree (frozen parts have no state)."""
+        return ()
+
+
+# Constant of the tanh approximation of GELU, sqrt(2 / pi). The formulas
+# below must match ``jax.nn.gelu`` with ``approximate=True`` (its default).
+_GELU_C = 0.7978845608028654
+_GELU_A = 0.044715
+
+
+def _gelu_forward(x: jnp.ndarray) -> tuple[jnp.ndarray, tuple]:
+    return jax.nn.gelu(x), (x,)
+
+
+def _gelu_backward(cache: tuple, error: jnp.ndarray) -> jnp.ndarray:
+    # Derivative of the tanh approximation
+    #   gelu(x) = 0.5 x (1 + tanh(c (x + a x^3))),
+    #   gelu'(x) = 0.5 (1 + t) + 0.5 x (1 - t^2) c (1 + 3 a x^2),  t = tanh(...).
+    (x,) = cache
+    t = jnp.tanh(_GELU_C * (x + _GELU_A * x**3))
+    slope = 0.5 * (1.0 + t) + 0.5 * x * (1.0 - t**2) * _GELU_C * (
+        1.0 + 3.0 * _GELU_A * x**2
+    )
+    return error * slope
+
+
+def gelu_adapter() -> EquinoxAdapter:
+    """Build a frozen GELU: the error is multiplied by the slope at the cached input."""
+    return EquinoxAdapter(_gelu_forward, _gelu_backward)
+
+
+def layer_norm_adapter(layer_norm: eqx.nn.LayerNorm) -> EquinoxAdapter:
+    """Build a frozen LayerNorm around an ``eqx.nn.LayerNorm``'s parameters.
+
+    Forward, each row is centred, divided by its spread, then scaled and shifted by the
+    (frozen) ``weight``/``bias``. Backward, the error is scaled by ``weight``, then the
+    centring and rescaling are undone: the error's own row-average and its overlap with
+    the normalised input are subtracted before dividing by the spread — the two
+    subtractions account for the fact that shifting or stretching a whole row leaves its
+    normalisation unchanged.
+    """
+    gamma = layer_norm.weight if layer_norm.weight is not None else 1.0
+    beta = layer_norm.bias if layer_norm.bias is not None else 0.0
+    eps = layer_norm.eps
+
+    def forward(x: jnp.ndarray) -> tuple[jnp.ndarray, tuple]:
+        mean = x.mean(axis=-1, keepdims=True)
+        std = jnp.sqrt(x.var(axis=-1, keepdims=True) + eps)
+        normed = (x - mean) / std
+        return gamma * normed + beta, (normed, std)
+
+    def backward(cache: tuple, error: jnp.ndarray) -> jnp.ndarray:
+        normed, std = cache
+        scaled = error * gamma
+        return (
+            scaled
+            - scaled.mean(axis=-1, keepdims=True)
+            - normed * (scaled * normed).mean(axis=-1, keepdims=True)
+        ) / std
+
+    return EquinoxAdapter(forward, backward)
+
+
+def linear_adapter(linear: eqx.nn.Linear) -> EquinoxAdapter:
+    """Build a frozen linear map around an ``eqx.nn.Linear``'s parameters.
+
+    Forward, ``x @ weight.T (+ bias)`` on the last axis. Backward, the error is
+    multiplied back through the weight matrix (``error @ weight``) — the exact input
+    error of a linear map, no derivation needed. The bias, being added, passes the error
+    through untouched.
+    """
+    weight = jnp.asarray(linear.weight)
+    bias = None if linear.bias is None else jnp.asarray(linear.bias)
+
+    def forward(x: jnp.ndarray) -> tuple[jnp.ndarray, tuple]:
+        y = x @ weight.T
+        if bias is not None:
+            y = y + bias
+        return y, ()
+
+    def backward(cache: tuple, error: jnp.ndarray) -> jnp.ndarray:
+        return error @ weight
+
+    return EquinoxAdapter(forward, backward)
+
+
+class DeepNetworkAdapter(PCModule):
+    """A learning part: a PyHGF :class:`~pyhgf.model.DeepNetwork` in the pipeline.
+
+    Declares the wrapped network and how it learns; the executor runs one
+    batch-synchronous local learning step per training step (the same
+    computation as :meth:`~pyhgf.model.DeepNetwork.batch_update`, staged
+    in-trace) and threads the error at the network's input onward.
+
+    The learning part's boundary is where the descent-error convention of the
+    pipeline meets PyHGF's observed-minus-predicted convention:
+
+    - the error *enters* by clamping ``output - error`` as the observation
+      the network should have produced (so the leaf prediction error is
+      exactly ``-error``);
+    - the error *leaves* as the negated input-layer prediction error.
+
+    Parameters
+    ----------
+    net :
+        The wrapped network. Its top (input) layer width is the part's input
+        size; its bottom (output) layer width is the part's output size.
+    optimizer :
+        Optax optimiser for the local weight step. ``None`` freezes the
+        weights (the beliefs still update).
+    learning_kind :
+        Weight-gradient mode, as in :meth:`~pyhgf.model.DeepNetwork.fit`.
+    update_confidences :
+        Whether the confidence state adapts across batches (see
+        :meth:`~pyhgf.model.DeepNetwork.batch_update`). Defaults to False —
+        the setting used for exact comparisons against backpropagation.
+    time_step :
+        Inference time step — scales the confidence leak per batch (one batch
+        counts as one observation of duration ``time_step``).
+    """
+
+    def __init__(
+        self,
+        net: DeepNetwork,
+        optimizer: Optional[optax.GradientTransformation] = None,
+        learning_kind: str = "precision_weighted",
+        update_confidences: bool = False,
+        time_step: float = 1.0,
+    ):
+        self.net = net
+        self.optimizer = optimizer
+        self.learning_kind = learning_kind
+        self.update_confidences = update_confidences
+        self.time_step = time_step
+
+    def init_state(self) -> tuple:
+        """Return the ``(network, opt_state)`` state pytree.
+
+        ``opt_state`` is None when ``optimizer`` is None (weights frozen, beliefs
+        still update); otherwise it is initialized here if not already set.
+
+        Raises
+        ------
+        ValueError
+            If the network has no layers yet (call ``net.add_layer(...)`` first).
+        """
+        if self.net.state is None:
+            raise ValueError(
+                "Network has no layers yet. Call add_layer(...) before init_state()."
+            )
+
+        opt_state = self.net.opt_state
+        if self.optimizer is not None and opt_state is None:
+            opt_state = self.optimizer.init(self.net.state.weights_tuple())
+
+        return (self.net.state, opt_state)
+
+
+class PCSequential(PCModule):
+    """A chain of parts: forward in order to predict, in reverse to update."""
+
+    def __init__(self, parts: list):
+        self.parts = list(parts)
+
+    def init_state(self) -> tuple:
+        """Return a tuple of each child part's state, in ``self.parts`` order."""
+        return tuple(part.init_state() for part in self.parts)
+
+
+class Residual(PCModule):
+    """The shortcut junction: ``output = input + branch(input)``.
+
+    Backward, the error is copied into both routes — unchanged along the
+    shortcut, translated through the branch — and the two messages add.
+    """
+
+    def __init__(self, branch: PCModule):
+        self.branch = branch
+
+    def init_state(self):
+        """Return the branch's state (the shortcut itself carries no state)."""
+        return self.branch.init_state()

--- a/pyhgf/model/transformer.py
+++ b/pyhgf/model/transformer.py
@@ -1,0 +1,270 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+"""A GPT-style Transformer as a mixed pipeline.
+
+Assembles the parts from :mod:`pyhgf.model.hybrid` into the architecture of the
+reference Transformer (see ``docs/source/notebooks/0.8-Transformers.ipynb``):
+embeddings, repeated blocks of attention and feed-forward sub-layers with normalisation
+and shortcut junctions, a final normalisation, and an output head. Any slot can hold a
+frozen calculation or a learning PyHGF network; errors travel backward part by part,
+with no global backward sweep (see :mod:`pyhgf.model.hybrid` for the conventions and
+:mod:`pyhgf.model.fused` for the executor).
+
+The one part specific to Transformers is :class:`MultiHeadAttention`: the only place
+where token positions exchange information. Its four weight tables (Q, K, V, O) are
+ordinary per-position parts; the *mixing* between them — compare queries against keys,
+turn the scores into attention percentages, blend the values — has no weights of its
+own, so its role in the backward pass is purely to re-route errors across positions,
+using a hand-derived formula (no automatic differentiation).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import jax
+import jax.numpy as jnp
+
+from pyhgf.model.hybrid import (
+    PCModule,
+    PCSequential,
+    Residual,
+    gelu_adapter,
+    layer_norm_adapter,
+    linear_adapter,
+)
+
+__all__ = [
+    "MultiHeadAttention",
+    "HybridGPT",
+    "hybrid_from_gpt",
+]
+
+
+class MultiHeadAttention(PCModule):
+    """Causal multi-head self-attention as a composite pipeline part.
+
+    Holds four single-input parts for the Q, K, V, and O weight tables (any
+    mix of frozen and learning parts) around the weight-free mixing step.
+    Operates on ``(batch, seq, features)`` arrays — attention is the one
+    part that needs the sequence axis explicit, because it moves information
+    *between* positions; everywhere else each position is independent.
+
+    Forward: every position emits a query, a key, and a value through the
+    Q/K/V parts; each position's attention scores against all *earlier*
+    positions (causal mask) become percentages through a softmax; the values
+    are blended accordingly and pass through the O part.
+
+    Backward: the error at the output goes back through O, is re-routed
+    across positions by the mixing formula (an error at position ``t`` flows
+    back to the positions ``t`` attended to, and to the query/key pair that
+    set those percentages), and the three resulting messages return through
+    Q, K, and V — whose input errors add, since all three read the same
+    input.
+    """
+
+    def __init__(
+        self,
+        wq: PCModule,
+        wk: PCModule,
+        wv: PCModule,
+        wo: PCModule,
+        n_heads: int,
+    ):
+        self.wq, self.wk, self.wv, self.wo = wq, wk, wv, wo
+        self.n_heads = n_heads
+
+    def init_state(self) -> tuple:
+        """Return the ``(q, k, v, o)`` tuple of the four weight tables' states."""
+        return (
+            self.wq.init_state(),
+            self.wk.init_state(),
+            self.wv.init_state(),
+            self.wo.init_state(),
+        )
+
+
+def _split_heads(a: jnp.ndarray, n_heads: int) -> jnp.ndarray:
+    # (B, T, D) -> (B, H, T, D // H)
+    b, t, d = a.shape
+    return a.reshape(b, t, n_heads, d // n_heads).transpose(0, 2, 1, 3)
+
+
+def _merge_heads(a: jnp.ndarray) -> jnp.ndarray:
+    # (B, H, T, hd) -> (B, T, D)
+    b, h, t, hd = a.shape
+    return a.transpose(0, 2, 1, 3).reshape(b, t, h * hd)
+
+
+def _mixing_forward(
+    q: jnp.ndarray, k: jnp.ndarray, v: jnp.ndarray, n_heads: int
+) -> tuple[jnp.ndarray, tuple]:
+    """Compute the weight-free attention mixing.
+
+    Splits the query/key/value streams into heads, scores every position against the
+    earlier positions (causal mask), softmaxes the scores into attention percentages,
+    and blends the values. Returns the blended context, ``(batch, seq, features)``, and
+    the head-shaped cache the backward pass needs. Plain and unjitted: it is staged into
+    the executor's compiled step.
+    """
+    qh = _split_heads(q, n_heads)
+    kh = _split_heads(k, n_heads)
+    vh = _split_heads(v, n_heads)
+
+    seq_len, head_dim = qh.shape[2], qh.shape[-1]
+    scores = qh @ kh.transpose(0, 1, 3, 2) / jnp.sqrt(float(head_dim))
+    causal_mask = jnp.tril(jnp.ones((seq_len, seq_len)))
+    scores = jnp.where(causal_mask[None, None] == 0, -jnp.inf, scores)
+    attn = jax.nn.softmax(scores, axis=-1)
+
+    return _merge_heads(attn @ vh), (attn, qh, kh, vh)
+
+
+def _mixing_backward(
+    cache: tuple, d_ctx: jnp.ndarray
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Re-route the context error across positions — the mixing's backward.
+
+    An error at position ``t`` flows back to the positions ``t`` attended to (through
+    the cached attention percentages), and to the query/key pair that set those
+    percentages (through the softmax, where the row-weighted mean of the incoming error
+    is subtracted because each row of percentages sums to one; masked positions carry
+    zero attention and drop out automatically).
+    """
+    attn, qh, kh, vh = cache
+    head_dim = qh.shape[-1]
+
+    d_ctx_h = _split_heads(d_ctx, attn.shape[1])
+    d_attn = d_ctx_h @ vh.transpose(0, 1, 3, 2)
+    d_v = attn.transpose(0, 1, 3, 2) @ d_ctx_h
+    d_scores = (
+        attn * (d_attn - (d_attn * attn).sum(axis=-1, keepdims=True))
+    ) / jnp.sqrt(float(head_dim))
+    d_q = d_scores @ kh
+    d_k = d_scores.transpose(0, 1, 3, 2) @ qh
+
+    return _merge_heads(d_q), _merge_heads(d_k), _merge_heads(d_v)
+
+
+class HybridGPT:
+    """The full Transformer as a mixed pipeline, from token ids to logits.
+
+    The embeddings sit outside the part contract (token ids are integers,
+    not features). By default they are frozen lookup tables held directly.
+    Passing ``token_part`` / ``position_part`` (learning parts fed one-hot
+    rows, e.g. built with :func:`~pyhgf.model.transplant.from_embedding`)
+    makes them learn: a lookup equals a one-hot vector times the table, so
+    the parts see one-hot inputs and receive the error at the embedding
+    output. The rest of the model — blocks, final normalisation, head — is
+    one :class:`~pyhgf.model.hybrid.PCSequential` over
+    ``(batch, seq, features)`` arrays.
+
+    Run it with :class:`~pyhgf.model.fused.FusedPipeline`, whose ``step``
+    and ``predict`` take batches of integer token-id sequences,
+    ``(batch, seq)``.
+    """
+
+    def __init__(
+        self,
+        tok_table: jnp.ndarray,
+        pos_table: jnp.ndarray,
+        pipeline: PCSequential,
+        token_part=None,
+        position_part=None,
+    ):
+        self.tok_table = jnp.asarray(tok_table)
+        self.pos_table = jnp.asarray(pos_table)
+        self.pipeline = pipeline
+        self.token_part = token_part
+        self.position_part = position_part
+
+    def init_state(self) -> tuple:
+        """Return ``(pipeline_state, token_state, position_state)``.
+
+        The embedding states are empty tuples when their parts are frozen.
+        """
+        token_state = self.token_part.init_state() if self.token_part else ()
+        position_state = self.position_part.init_state() if self.position_part else ()
+        return (self.pipeline.init_state(), token_state, position_state)
+
+
+def hybrid_from_gpt(
+    gpt,
+    ff_parts: Optional[list] = None,
+    attention_parts: Optional[list] = None,
+    head_part: Optional[PCModule] = None,
+    token_part: Optional[PCModule] = None,
+    position_part: Optional[PCModule] = None,
+) -> HybridGPT:
+    """Assemble a :class:`HybridGPT` from a reference Equinox GPT.
+
+    Expects the attribute layout of the reference model in
+    ``docs/source/notebooks/0.8-Transformers.ipynb``: ``tok_emb``,
+    ``pos_emb``, ``blocks`` (each with ``attn.wq/wk/wv/wo``, ``ff.fc1/fc2``,
+    ``n1``, ``n2``), ``norm_f``, and ``head``. Every slot is frozen at the
+    given model's weights unless a learning part is supplied for it.
+
+    With all slots frozen, the assembled pipeline computes exactly the same
+    function as the Equinox model — the transplant wiring gate. Supplying
+    parts (e.g. :class:`~pyhgf.model.hybrid.DeepNetworkAdapter`s built by
+    the :mod:`~pyhgf.model.transplant` converters) turns the corresponding
+    slots into PyHGF learners while everything else stays pinned — from the
+    single-component swap experiment up to a model whose every weight learns
+    through PyHGF, with only the weightless calculations (normalisations,
+    attention mixing) frozen.
+
+    Parameters
+    ----------
+    gpt :
+        The Equinox reference model whose weights are transplanted.
+    ff_parts :
+        Optional list of parts, one per block, replacing the frozen
+        feed-forwards.
+    attention_parts :
+        Optional list of dicts, one per block, with keys ``"wq"``, ``"wk"``,
+        ``"wv"``, ``"wo"``, replacing the frozen attention weight tables.
+    head_part :
+        Optional part replacing the frozen output head.
+    token_part, position_part :
+        Optional parts replacing the frozen embedding tables (fed one-hot
+        rows — see :class:`HybridGPT`).
+
+    Returns
+    -------
+    HybridGPT
+        The assembled mixed pipeline.
+    """
+    layers: list = []
+    for i, block in enumerate(gpt.blocks):
+        attn_tables = attention_parts[i] if attention_parts is not None else {}
+        attention = MultiHeadAttention(
+            wq=attn_tables.get("wq") or linear_adapter(block.attn.wq),
+            wk=attn_tables.get("wk") or linear_adapter(block.attn.wk),
+            wv=attn_tables.get("wv") or linear_adapter(block.attn.wv),
+            wo=attn_tables.get("wo") or linear_adapter(block.attn.wo),
+            n_heads=block.attn.n_heads,
+        )
+        if ff_parts is not None:
+            feed_forward = ff_parts[i]
+        else:
+            feed_forward = PCSequential([
+                linear_adapter(block.ff.fc1),
+                gelu_adapter(),
+                linear_adapter(block.ff.fc2),
+            ])
+        layers.append(
+            PCSequential([
+                Residual(PCSequential([layer_norm_adapter(block.n1), attention])),
+                Residual(PCSequential([layer_norm_adapter(block.n2), feed_forward])),
+            ])
+        )
+    layers.append(layer_norm_adapter(gpt.norm_f))
+    layers.append(head_part if head_part is not None else linear_adapter(gpt.head))
+
+    return HybridGPT(
+        tok_table=gpt.tok_emb.weight,
+        pos_table=gpt.pos_emb.weight,
+        pipeline=PCSequential(layers),
+        token_part=token_part,
+        position_part=position_part,
+    )

--- a/pyhgf/updates/vectorized/learning.py
+++ b/pyhgf/updates/vectorized/learning.py
@@ -82,6 +82,54 @@ def vectorized_weight_gradient(
     ValueError
         If *kind* is unrecognised.
     """
+    u, v = vectorized_weight_gradient_factors(
+        parent_state,
+        child_state,
+        coupling_fn,
+        kind=kind,
+        parent_has_constant=parent_has_constant,
+        child_is_binary=child_is_binary,
+    )
+    return u[:, None] * v[None, :]
+
+
+def vectorized_weight_gradient_factors(
+    parent_state: LayerState,
+    child_state: LayerState,
+    coupling_fn: Callable,
+    kind: str = "precision_weighted",
+    parent_has_constant: bool = False,
+    child_is_binary: bool = False,
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Child- and parent-side factors of the weight gradient.
+
+    The descent gradient of :func:`vectorized_weight_gradient` is a rank-one
+    product, ``grad = u[:, None] * v[None, :]``. Returning the two vectors
+    instead of their product lets a batched caller average gradients over many
+    samples with a single contraction (``einsum('bi,bj->ij') / batch``) — the
+    same arithmetic, but without materialising one weight-matrix-sized gradient
+    per sample, which is what dominates memory traffic at scale.
+
+    Non-finite entries are zeroed on the factors, matching the per-entry
+    zeroing of :func:`vectorized_weight_gradient` for vector-borne NaN/inf.
+
+    Parameters
+    ----------
+    parent_state, child_state, coupling_fn, kind, parent_has_constant, child_is_binary :
+        As in :func:`vectorized_weight_gradient`.
+
+    Returns
+    -------
+    (u, v) :
+        Child-side factor, shape ``(n_children,)``, and parent-side factor,
+        shape ``(n_parents[+1],)``, such that ``u[:, None] * v[None, :]``
+        equals the descent gradient.
+
+    Raises
+    ------
+    ValueError
+        If *kind* is unrecognised.
+    """
     if kind not in SEPARABLE_KINDS:
         raise ValueError(f"Unknown kind '{kind}'. Expected one of {SEPARABLE_KINDS}.")
 
@@ -103,4 +151,4 @@ def vectorized_weight_gradient(
     v = jnp.where(jnp.isfinite(v), v, 0.0)
 
     # Descent sign, folded into the child-side factor.
-    return -u[:, None] * v[None, :]
+    return -u, v

--- a/pyhgf/utils/vectorized_belief_propagation.py
+++ b/pyhgf/utils/vectorized_belief_propagation.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import dataclasses
+from typing import Optional
 
 import equinox as eqx
 import jax
@@ -28,7 +29,10 @@ from pyhgf.updates.vectorized.categorical import (
     vectorized_categorical_prediction,
     vectorized_categorical_prediction_error,
 )
-from pyhgf.updates.vectorized.learning import vectorized_weight_gradient
+from pyhgf.updates.vectorized.learning import (
+    vectorized_weight_gradient,
+    vectorized_weight_gradient_factors,
+)
 from pyhgf.updates.vectorized.volatile import (
     vectorized_layer_posterior_update,
     vectorized_layer_prediction,
@@ -410,10 +414,10 @@ def _bottomup_posterior_pe(
 # ---------------------------------------------------------------------------
 
 
-def _grad_layer(parent: Layer, child_elem, learning_kind: str):
-    """Per-Layer weight gradient (same shape as ``parent.weights_in``)."""
+def _layer_weight_op(kernel, parent: Layer, child_elem, learning_kind: str):
+    """Apply a per-layer weight kernel to a ``Layer`` parent and its child."""
     child_state, child_kind, _ = _child_view(child_elem)
-    return vectorized_weight_gradient(
+    return kernel(
         parent_state=parent.state,
         child_state=child_state,
         coupling_fn=parent.coupling_fn,
@@ -423,13 +427,14 @@ def _grad_layer(parent: Layer, child_elem, learning_kind: str):
     )
 
 
-def _grad_stack(stack: LayerStack, child_elem, learning_kind: str):
-    """Per-slice weight gradients for a ``LayerStack``.
+def _stack_weight_op(kernel, stack: LayerStack, child_elem, learning_kind: str):
+    """Apply a per-layer weight kernel to every slice of a ``LayerStack``.
 
     The child of slice 0 is the layer below the stack (``child_elem``); the child of
     slice k>0 is slice k-1 within the stack. Pre-pend the external child's state to the
-    stack's state along axis 0 to form an ``(N+1, ...)`` array, then ``vmap`` the per-
-    slice grad over the N parent slices and the N child slots.
+    stack's state along axis 0 to form an ``(N+1, ...)`` array, then ``vmap`` the kernel
+    over the N parent slices (``stack.state``) and the N child slots
+    (``combined[:-1]``).
     """
     child_state, _, _ = _child_view(child_elem)
     child_state = _match_child_vol_structure(child_state, stack.has_volatility_parent)
@@ -439,12 +444,10 @@ def _grad_stack(stack: LayerStack, child_elem, learning_kind: str):
         child_state,
         stack.state,
     )
-    # parent_states[k] = stack.state[k]; child_states[k] = combined[k]
-    parent_states = stack.state
     child_states = jax.tree_util.tree_map(lambda x: x[:-1], combined_state)
 
     def per_slice(parent_state, child_state_for_slice):
-        return vectorized_weight_gradient(
+        return kernel(
             parent_state=parent_state,
             child_state=child_state_for_slice,
             coupling_fn=stack.coupling_fn,
@@ -453,14 +456,28 @@ def _grad_stack(stack: LayerStack, child_elem, learning_kind: str):
             child_is_binary=False,
         )
 
-    return jax.vmap(per_slice)(parent_states, child_states)
+    return jax.vmap(per_slice)(stack.state, child_states)
+
+
+def _weight_op(kernel, parent_elem, child_elem, learning_kind: str):
+    """Dispatch a per-layer weight kernel on ``Layer`` vs ``LayerStack``."""
+    if isinstance(parent_elem, LayerStack):
+        return _stack_weight_op(kernel, parent_elem, child_elem, learning_kind)
+    return _layer_weight_op(kernel, parent_elem, child_elem, learning_kind)
 
 
 def _weight_grad(parent_elem, child_elem, learning_kind: str):
-    """Weight gradient for ``parent_elem.weights_in``."""
-    if isinstance(parent_elem, LayerStack):
-        return _grad_stack(parent_elem, child_elem, learning_kind)
-    return _grad_layer(parent_elem, child_elem, learning_kind)
+    """Weight gradient (same shape as ``parent_elem.weights_in``)."""
+    return _weight_op(
+        vectorized_weight_gradient, parent_elem, child_elem, learning_kind
+    )
+
+
+def _weight_factor(parent_elem, child_elem, learning_kind: str):
+    """Rank-one gradient factors ``(u, v)`` for ``parent_elem.weights_in``."""
+    return _weight_op(
+        vectorized_weight_gradient_factors, parent_elem, child_elem, learning_kind
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -551,61 +568,19 @@ def propagation_step(
         `opt_state` are updated and `surprise` is the step's surprise.
     """
     x, y = inputs
-    elements = list(network.layers)
-    n_elements = len(elements)
-    max_posterior_precision = network.max_posterior_precision
-    volatility_updates = network.volatility_updates
-    precision_clipping_value = network.precision_clipping_value
 
-    # 1. Set predictors on the top element.
-    elements[-1] = _set_top_predictors(elements[-1], x)
+    # Belief propagation: top-down prediction (clamping x on top) then the
+    # bottom-up PE + posterior sweep (clamping y at the bottom).
+    swept = _update_sweep(_prediction_sweep(network, x, time_step=time_step), y)
 
-    # 2. Clamp observations on the bottom element.
-    elements[0] = _set_bottom_observations(elements[0], y)
-
-    # 3. Top-down prediction: predict each element from the one above.
-    for i in range(n_elements - 1, 0, -1):
-        elements[i - 1] = _topdown_predict(
-            elements[i],
-            elements[i - 1],
-            time_step=time_step,
-            precision_clipping_value=precision_clipping_value,
-        )
-
-    # 4a. PE on the bottom (leaf) element.
-    elements[0] = _leaf_pe(
-        elements[0],
-        volatility_updates=volatility_updates,
-        max_posterior_precision=max_posterior_precision,
-    )
-
-    # 4b. Interleaved bottom-up: posterior + PE on every interior element.
-    for i in range(1, n_elements - 1):
-        elements[i] = _bottomup_posterior_pe(
-            elements[i],
-            elements[i - 1],
-            volatility_updates=volatility_updates,
-            max_posterior_precision=max_posterior_precision,
-        )
-
-    # 5. Weight learning — same optax flow as before, but element-shaped grads.
+    # Optional weight-learning phase.
     if weight_update:
-        weights = tuple(elem.weights_in for elem in elements)
-        grads_list: list = [None]  # bottom element has no weights_in
-        for i in range(1, n_elements):
-            grads_list.append(_weight_grad(elements[i], elements[i - 1], learning_kind))
-        grads = tuple(grads_list)
-
-        updates, new_opt_state = optimizer.update(grads, opt_state, weights)
-        new_weights = optax.apply_updates(weights, updates)
-
-        for i, new_w in enumerate(new_weights):
-            if new_w is not None:
-                elements[i] = _writeback_weights(elements[i], new_w)
+        new_network, new_opt_state = _learn_sweep(
+            swept, opt_state, optimizer, learning_kind
+        )
     else:
-        new_opt_state = opt_state
+        new_network, new_opt_state = swept, opt_state
 
-    new_network = dataclasses.replace(network, layers=tuple(elements))
     output_pred = new_network.layers[0].state.expected_mean
     return (new_network, new_opt_state), output_pred
 
@@ -699,6 +674,479 @@ def _state_for_record(elem):
     return elem.state
 
 
+def _prediction_sweep(
+    network: Network, x: jnp.ndarray, *, time_step: float = 1.0
+) -> Network:
+    """Top-down prediction sweep, returning the updated network.
+
+    Clamps the predictors on the top element and predicts every element from the one
+    above. No prediction errors, posterior updates, or weight learning are performed.
+    """
+    elements = list(network.layers)
+    n_elements = len(elements)
+
+    elements[-1] = _set_top_predictors(elements[-1], x)
+
+    for i in range(n_elements - 1, 0, -1):
+        elements[i - 1] = _topdown_predict(
+            elements[i],
+            elements[i - 1],
+            time_step=time_step,
+            precision_clipping_value=network.precision_clipping_value,
+        )
+
+    return dataclasses.replace(network, layers=tuple(elements))
+
+
+def _update_sweep(network: Network, y: jnp.ndarray) -> Network:
+    """Bottom-up prediction-error + posterior-update sweep, returning the network.
+
+    Clamps the observations on the bottom element, computes the leaf prediction error,
+    then performs the interleaved posterior-update + PE for every interior element, in
+    bottom-up order. Belief states are updated; inter-layer weights are not.
+    """
+    elements = list(network.layers)
+    n_elements = len(elements)
+
+    # Clamp observations and compute the leaf prediction error.
+    elements[0] = _set_bottom_observations(elements[0], y)
+    elements[0] = _leaf_pe(
+        elements[0],
+        volatility_updates=network.volatility_updates,
+        max_posterior_precision=network.max_posterior_precision,
+    )
+
+    # Interleaved bottom-up posterior + PE on every interior element.
+    for i in range(1, n_elements - 1):
+        elements[i] = _bottomup_posterior_pe(
+            elements[i],
+            elements[i - 1],
+            volatility_updates=network.volatility_updates,
+            max_posterior_precision=network.max_posterior_precision,
+        )
+
+    return dataclasses.replace(network, layers=tuple(elements))
+
+
+@eqx.filter_jit
+def prediction_sweep(network: Network, x: jnp.ndarray) -> Network:
+    """JIT-compiled top-down prediction sweep.
+
+    See :func:`_prediction_sweep`.
+    """
+    return _prediction_sweep(network, x)
+
+
+@eqx.filter_jit
+def update_sweep(network: Network, y: jnp.ndarray) -> Network:
+    """JIT-compiled bottom-up PE + posterior sweep.
+
+    See :func:`_update_sweep`.
+    """
+    return _update_sweep(network, y)
+
+
+def _input_prediction_error(network: Network) -> jnp.ndarray:
+    r"""Prediction error routed to the network's input (top) layer.
+
+    The bottom-up sweep (:func:`_update_sweep`) never touches the top layer:
+    its values are clamped to the predictors ``x``, so it receives no
+    posterior update and no prediction error. This function computes the
+    error message the top layer *would* receive from the layer below it —
+    the same confidence-weighted quantity that drives the posterior mean
+    shift of every interior layer:
+
+    .. math::
+
+        \varepsilon_x = g'(\hat{\mu}_x) \odot W^\top (g_a \, \delta_a),
+
+    where :math:`\delta_a` is the child layer's value prediction error,
+    :math:`g_a` its smoothing gain (the same gain used by
+    :func:`pyhgf.updates.vectorized.volatile.posterior.vectorized_posterior_update_mean_value_level`),
+    :math:`W` the weight matrix connecting the child into the top layer
+    (bias column excluded), and :math:`g'` the derivative of the top layer's
+    coupling function at the clamped predictors.
+
+    With unit precisions and an identity coupling this reduces to
+    :math:`W^\top \delta_a` — the error multiplied back through the weights.
+    Because prediction errors follow the ``observed - predicted`` convention,
+    the result is the *negative* of the gradient of a squared-error loss with
+    respect to the predictors.
+
+    Must be called after the update sweep, so the child layer carries its
+    posterior prediction error.
+
+    Parameters
+    ----------
+    network :
+        The network state, after :func:`_update_sweep`.
+
+    Returns
+    -------
+    jnp.ndarray
+        The prediction error at the top layer, shape ``(n_input_features,)``.
+    """
+    top = network.layers[-1]
+    if isinstance(top, LayerStack):
+        raise NotImplementedError("Top of network must be a Layer, not a LayerStack.")
+    if top.weights_in is None:
+        raise ValueError(
+            "The network has a single layer: there is no layer below the "
+            "input layer to route an error from."
+        )
+    child_state, _, _ = _child_view(network.layers[-2])
+
+    weights = top.weights_in
+    if top.add_constant_input:
+        # The bias column connects the constant node, not a real input.
+        weights = weights[:, :-1]
+
+    # Smoothing gain of the child layer — identical to the gain used by the
+    # interior posterior mean update, so the top layer sees exactly the
+    # message any interior layer would see.
+    pi_y = child_state.precision - child_state.expected_precision
+    gain = (
+        child_state.conditional_expected_precision
+        * child_state.precision
+        / (child_state.conditional_expected_precision + pi_y)
+    )
+
+    coupling_prime = jax.vmap(jax.grad(top.coupling_fn))(top.state.expected_mean)
+    return (
+        jnp.matmul(weights.T, gain * child_state.value_prediction_error)
+        * coupling_prime
+    )
+
+
+@eqx.filter_jit
+def input_prediction_error(network: Network) -> jnp.ndarray:
+    """JIT-compiled prediction error at the input (top) layer.
+
+    See :func:`_input_prediction_error`.
+    """
+    return _input_prediction_error(network)
+
+
+def _weight_gradients(network: Network, learning_kind: str) -> tuple:
+    """Per-element weight gradients, without applying them.
+
+    Must run *after* :func:`_update_sweep`, so the per-layer states already carry their
+    prediction errors / posteriors. Returns one gradient per element, matched 1:1 to
+    ``network.layers`` (``None`` for the bottom element, which has no incoming weights).
+    Gradients are in descent form, ready for optax.
+    """
+    elements = network.layers
+    grads_list: list = [None]  # bottom element has no weights_in
+    for i in range(1, len(elements)):
+        grads_list.append(_weight_grad(elements[i], elements[i - 1], learning_kind))
+    return tuple(grads_list)
+
+
+def _apply_weight_updates(
+    network: Network,
+    grads: tuple,
+    opt_state: optax.OptState,
+    optimizer: optax.GradientTransformation,
+) -> tuple[Network, optax.OptState]:
+    """One optimiser step on every ``weights_in``, from precomputed gradients."""
+    elements = list(network.layers)
+    weights = tuple(elem.weights_in for elem in elements)
+
+    updates, new_opt_state = optimizer.update(grads, opt_state, weights)
+    new_weights = optax.apply_updates(weights, updates)
+    for i, new_w in enumerate(new_weights):
+        if new_w is not None:
+            elements[i] = _writeback_weights(elements[i], new_w)
+
+    return dataclasses.replace(network, layers=tuple(elements)), new_opt_state
+
+
+def _learn_sweep(
+    network: Network,
+    opt_state: optax.OptState,
+    optimizer: optax.GradientTransformation,
+    learning_kind: str = "precision_weighted",
+) -> tuple[Network, optax.OptState]:
+    """Weight-learning phase: PE-driven gradients + an optimiser step.
+
+    Mirrors the weight-update block of :func:`propagation_step`. Must run *after*
+    :func:`_update_sweep`, so the per-layer states already carry their prediction errors
+    / posteriors. Updates ``weights_in`` on every element that has them.
+    """
+    grads = _weight_gradients(network, learning_kind)
+    return _apply_weight_updates(network, grads, opt_state, optimizer)
+
+
+@eqx.filter_jit
+def learn_sweep(
+    network: Network,
+    opt_state: optax.OptState,
+    optimizer: optax.GradientTransformation,
+    learning_kind: str,
+) -> tuple[Network, optax.OptState]:
+    """JIT-compiled weight-learning phase.
+
+    See :func:`_learn_sweep`.
+    """
+    return _learn_sweep(network, opt_state, optimizer, learning_kind)
+
+
+# ---------------------------------------------------------------------------
+# Pure per-sample step + batch-synchronous learning
+# ---------------------------------------------------------------------------
+
+# The state fields that carry information from one sample to the next. Every
+# other field is rewritten by the sweeps: expected means and precisions come
+# from the prediction sweep, posterior means are rebuilt as expected mean +
+# correction. What persists is the confidence side — the value-level
+# posterior precision (each prediction reads the previous one) and the
+# volatility level's belief.
+_CARRIED_FIELDS: tuple = ("precision", "mean_vol", "precision_vol")
+
+
+def _confidence_increments(before: Network, after: Network) -> tuple:
+    """Per-element change of the carried confidence fields, ``after - before``.
+
+    Returns one ``dict`` per element, keyed by field name. For a ``Layer``
+    each entry has shape ``(n_nodes,)``; for a ``LayerStack``,
+    ``(n_slices, n_nodes)``.
+    """
+    # ``mean_vol``/``precision_vol`` are ``None`` on layers without a volatility
+    # parent — there is no volatility confidence to carry, so skip them.
+    return tuple(
+        {
+            field: getattr(elem_after.state, field) - getattr(elem_before.state, field)
+            for field in _CARRIED_FIELDS
+            if getattr(elem_before.state, field) is not None
+        }
+        for elem_before, elem_after in zip(before.layers, after.layers)
+    )
+
+
+def apply_confidence_increments(network: Network, increments: tuple) -> Network:
+    """Add confidence increments (see :func:`_confidence_increments`) to a network.
+
+    Used by :func:`batch_step` to carry the batch-averaged confidence change into the
+    state used by the next batch.
+    """
+    new_elements = []
+    for elem, inc in zip(network.layers, increments):
+        new_state = dataclasses.replace(
+            elem.state,
+            **{
+                field: getattr(elem.state, field) + inc[field]
+                for field in _CARRIED_FIELDS
+                if field in inc
+            },
+        )
+        new_elements.append(dataclasses.replace(elem, state=new_state))
+    return dataclasses.replace(network, layers=tuple(new_elements))
+
+
+def sample_step(
+    network: Network,
+    x: jnp.ndarray,
+    y: jnp.ndarray,
+    learning_kind: str = "precision_weighted",
+    time_step: float = 1.0,
+) -> tuple[jnp.ndarray, tuple, tuple]:
+    """One full local learning step for one sample, as a pure function.
+
+    Runs the prediction sweep (clamp ``x`` on top, predict downward) and the
+    update sweep (clamp ``y`` at the bottom, compute errors and correct
+    beliefs upward), then reads out everything a caller needs without
+    mutating anything:
+
+    Parameters
+    ----------
+    network :
+        The state template. Not modified; every call starting from the same
+        template sees the same weights and the same confidences, which is
+        what makes this function safe to ``jax.vmap`` over a batch of
+        samples.
+    x :
+        Predictors clamped on the top layer, shape ``(n_input_features,)``.
+    y :
+        Observations clamped on the bottom layer, shape
+        ``(n_output_features,)``.
+    learning_kind :
+        Weight-gradient mode, as in
+        :func:`pyhgf.updates.vectorized.learning.vectorized_weight_gradient`.
+    time_step :
+        Inference time step for the prediction sweep.
+
+    Returns
+    -------
+    input_error :
+        The prediction error at the input (top) layer — see
+        :func:`input_prediction_error`.
+    grads :
+        Per-element weight gradients (descent form, ``None`` for the bottom
+        element). Average these across a batch and apply once.
+    increments :
+        Per-element change of the carried confidence fields (value-level
+        posterior precision and the volatility level), relative to the
+        template. Average these across a batch and apply once with
+        :func:`apply_confidence_increments`.
+    """
+    updated = _update_sweep(_prediction_sweep(network, x, time_step=time_step), y)
+    return (
+        _input_prediction_error(updated),
+        _weight_gradients(updated, learning_kind),
+        _confidence_increments(network, updated),
+    )
+
+
+def _batch_step(
+    network: Network,
+    opt_state: Optional[optax.OptState],
+    x: jnp.ndarray,
+    y: jnp.ndarray,
+    optimizer: Optional[optax.GradientTransformation] = None,
+    learning_kind: str = "precision_weighted",
+    update_confidences: bool = True,
+    time_step: float = 1.0,
+    predicted: Optional[tuple] = None,
+) -> tuple[Network, Optional[optax.OptState], jnp.ndarray]:
+    """One batch-synchronous learning step over many samples at once.
+
+    Every sample in the batch is processed from the *same* state template —
+    same weights, same confidences — through the same sweeps as
+    :func:`sample_step`, under ``jax.vmap``, so samples are exchangeable and
+    nothing depends on their order. The per-sample results are then averaged
+    and applied once, so the batch counts as a single observation:
+
+    * weight gradients → one optimiser step (skipped when ``optimizer`` is
+      ``None``);
+    * confidence increments → added to the carried fields (skipped when
+      ``update_confidences`` is ``False``, e.g. to keep confidences pinned
+      during backprop-parity comparisons).
+
+    Averaging (rather than summing) makes the result invariant to repeating
+    the batch: the same samples twice produce the same step.
+
+    Parameters
+    ----------
+    network :
+        The state template shared by every sample in the batch.
+    opt_state :
+        The optimiser state, or ``None`` when ``optimizer`` is ``None``.
+    x :
+        Predictors, shape ``(batch, n_input_features)``.
+    y :
+        Observations, shape ``(batch, n_output_features)``.
+    optimizer :
+        Optax optimiser for the weight step. ``None`` freezes the weights.
+    learning_kind :
+        Weight-gradient mode.
+    update_confidences :
+        Whether to carry the batch-averaged confidence increments into the
+        returned network.
+    time_step :
+        Inference time step, applied once per batch.
+    predicted :
+        Optional per-sample predicted states from
+        :func:`batched_prediction_states` (one batched ``LayerState`` per
+        element). When given, the internal prediction sweep is skipped and
+        the update starts from these states — the forward pass a caller has
+        already run is not repeated. ``x`` is ignored in that case.
+
+    Returns
+    -------
+    network :
+        The template advanced by one batch: new weights and, if requested,
+        new confidences. Everything else is untouched (it is rewritten by
+        the sweeps on the next call anyway).
+    opt_state :
+        The advanced optimiser state (``None`` if no optimiser was given).
+    input_errors :
+        Per-sample prediction errors at the input layer, shape
+        ``(batch, n_input_features)`` — the messages a caller passes to
+        whatever sits behind this network.
+    """
+
+    # Each sample contributes only its two gradient factors (small vectors);
+    # the batch-mean gradient is then one contraction per weight matrix. This
+    # avoids materialising one weight-matrix-sized gradient per sample under
+    # vmap — the same arithmetic, a batch factor less memory traffic. Every
+    # gradient kind is separable, so this is the only path.
+    def finish_sample(swept: Network, yi):
+        updated = _update_sweep(swept, yi)
+        factors = None
+        if optimizer is not None:
+            factors = tuple(
+                [None]
+                + [
+                    _weight_factor(
+                        updated.layers[i], updated.layers[i - 1], learning_kind
+                    )
+                    for i in range(1, len(updated.layers))
+                ]
+            )
+        return (
+            _input_prediction_error(updated),
+            _confidence_increments(network, updated),
+            factors,
+        )
+
+    if predicted is None:
+
+        def per_sample(xi, yi):
+            return finish_sample(
+                _prediction_sweep(network, xi, time_step=time_step), yi
+            )
+
+        input_errors, increments, factors = jax.vmap(per_sample)(x, y)
+    else:
+        # Rebuild each sample's network around the shared (unbatched) weights
+        # and static fields; only the layer states carry a batch axis.
+        def per_sample_predicted(states_i, yi):
+            swept = dataclasses.replace(
+                network,
+                layers=tuple(
+                    dataclasses.replace(elem, state=state_i)
+                    for elem, state_i in zip(network.layers, states_i)
+                ),
+            )
+            return finish_sample(swept, yi)
+
+        input_errors, increments, factors = jax.vmap(per_sample_predicted)(predicted, y)
+
+    new_network = network
+    if optimizer is not None:
+        mean_grads = tuple(_contract_factors(f) for f in factors)
+        new_network, opt_state = _apply_weight_updates(
+            new_network, mean_grads, opt_state, optimizer
+        )
+
+    if update_confidences:
+        mean_increments = jax.tree_util.tree_map(lambda i: i.mean(axis=0), increments)
+        new_network = apply_confidence_increments(new_network, mean_increments)
+
+    return new_network, opt_state, input_errors
+
+
+# The compiled entry point. The implementation stays callable unjitted so a
+# larger compiled program (a fused pipeline step) can inline it.
+batch_step = eqx.filter_jit(_batch_step)
+
+
+def _contract_factors(factors) -> Optional[jnp.ndarray]:
+    """Batch-mean gradient from stacked per-sample factors.
+
+    ``factors`` is ``None`` for the bottom element, or a ``(u, v)`` pair with
+    a leading batch axis: ``(batch, n_children)`` and ``(batch, n_parents)``
+    for a ``Layer``; ``(batch, n_slices, ...)`` for a ``LayerStack``. The
+    mean over samples of ``u ⊗ v`` is computed as a single contraction.
+    """
+    if factors is None:
+        return None
+    u, v = factors
+    if u.ndim == 2:
+        return jnp.einsum("bi,bj->ij", u, v) / u.shape[0]
+    return jnp.einsum("bni,bnj->nij", u, v) / u.shape[0]
+
+
 @eqx.filter_jit
 def prediction_pass(network: Network, x: jnp.ndarray) -> jnp.ndarray:
     """Forward-only sweep through the network (no PE / posterior / learning).
@@ -719,17 +1167,68 @@ def prediction_pass(network: Network, x: jnp.ndarray) -> jnp.ndarray:
     expected_mean :
         The bottom element's ``expected_mean`` after the forward sweep.
     """
-    elements = list(network.layers)
-    n_elements = len(elements)
+    return _prediction_sweep(network, x).layers[0].state.expected_mean
 
-    elements[-1] = _set_top_predictors(elements[-1], x)
 
-    for i in range(n_elements - 1, 0, -1):
-        elements[i - 1] = _topdown_predict(
-            elements[i],
-            elements[i - 1],
-            time_step=1.0,
-            precision_clipping_value=network.precision_clipping_value,
-        )
+@eqx.filter_jit
+def batched_prediction_pass(network: Network, x: jnp.ndarray) -> jnp.ndarray:
+    """Forward-only sweep for a batch of samples, compiled once and reused.
 
-    return elements[0].state.expected_mean
+    The batched equivalent of :func:`prediction_pass`: every row of ``x`` is
+    an independent sample swept from the same network state. Used by
+    :meth:`pyhgf.model.DeepNetwork.predict` so repeated batched calls hit
+    the compilation cache instead of rebuilding the batching wrapper.
+
+    Parameters
+    ----------
+    network :
+        The current vectorised network state.
+    x :
+        Predictors, shape ``(batch, n_input_features)``.
+
+    Returns
+    -------
+    expected_mean :
+        The bottom element's ``expected_mean`` per sample, shape
+        ``(batch, n_output_features)``.
+    """
+    return jax.vmap(
+        lambda xi: _prediction_sweep(network, xi).layers[0].state.expected_mean
+    )(x)
+
+
+@eqx.filter_jit
+def batched_prediction_states(network: Network, x: jnp.ndarray) -> tuple:
+    """Batched forward sweep returning the per-sample swept states.
+
+    Like :func:`batched_prediction_pass`, but keeps what the sweep computed:
+    one batched ``LayerState`` per element (each field with a leading batch
+    axis). Passing these to :func:`batch_step` as ``predicted`` lets the
+    learning step start directly from them instead of repeating the forward
+    sweep — the weights and static fields are not duplicated per sample,
+    only the layer states are.
+
+    The states are the *only* output: the per-sample predictions are read
+    from the bottom element's ``expected_mean`` after the call. Returning
+    that array alongside the states from the same compiled function produces
+    incorrect values under the vmap-of-jit composition on CPU, so callers
+    must read it from the returned states.
+
+    Parameters
+    ----------
+    network :
+        The current vectorised network state.
+    x :
+        Predictors, shape ``(batch, n_input_features)``.
+
+    Returns
+    -------
+    states :
+        One batched ``LayerState`` per element, ordered as
+        ``network.layers``.
+    """
+
+    def one(xi):
+        return tuple(elem.state for elem in _prediction_sweep(network, xi).layers)
+
+    return jax.vmap(one)(x)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,376 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+"""Tests for declarative network building via configs.
+
+Validates that networks can be constructed from configuration dictionaries (JSON-like)
+and lists of LayerConfig objects, and that configs can be round-tripped to/from
+dictionaries for serialization.
+"""
+
+from __future__ import annotations
+
+import json
+
+import jax.nn
+import pytest
+
+from pyhgf.model import DeepNetwork, LayerConfig, resolve_coupling_fn
+
+
+class TestLayerConfig:
+    """Test LayerConfig dataclass and conversions."""
+
+    def test_layer_config_defaults(self):
+        """LayerConfig applies sensible defaults."""
+        cfg = LayerConfig(size=10)
+        assert cfg.size == 10
+        assert cfg.kind == "volatile"
+        assert cfg.add_constant_input is True
+        assert cfg.fully_connected is True
+        assert cfg.coupling_fn is None
+        assert cfg.volatility_parent is True
+
+    def test_layer_config_custom_values(self):
+        """LayerConfig accepts all custom values."""
+        cfg = LayerConfig(
+            size=20,
+            kind="binary",
+            add_constant_input=False,
+            coupling_fn="gelu",
+            tonic_volatility=-2.0,
+        )
+        assert cfg.size == 20
+        assert cfg.kind == "binary"
+        assert cfg.add_constant_input is False
+        assert cfg.coupling_fn == "gelu"
+        assert cfg.tonic_volatility == -2.0
+
+    def test_layer_config_to_dict_excludes_none(self):
+        """LayerConfig.to_dict() excludes None values for clean JSON."""
+        cfg = LayerConfig(
+            size=10,
+            coupling_fn="gelu",
+            tonic_volatility=None,  # Should be excluded
+        )
+        d = cfg.to_dict()
+        assert "size" in d
+        assert "coupling_fn" in d
+        assert "tonic_volatility" not in d
+        assert d["size"] == 10
+        assert d["coupling_fn"] == "gelu"
+
+    def test_layer_config_from_dict_tolerates_extra_keys(self):
+        """LayerConfig.from_dict() ignores unknown keys."""
+        d = {
+            "size": 15,
+            "coupling_fn": "relu",
+            "unknown_field": "ignored",
+        }
+        cfg = LayerConfig.from_dict(d)
+        assert cfg.size == 15
+        assert cfg.coupling_fn == "relu"
+
+    def test_layer_config_from_dict_missing_size_raises(self):
+        """LayerConfig.from_dict() requires 'size' key."""
+        with pytest.raises(TypeError):
+            LayerConfig.from_dict({"coupling_fn": "gelu"})
+
+    def test_layer_config_round_trip(self):
+        """LayerConfig can round-trip through to_dict() and from_dict()."""
+        original = LayerConfig(
+            size=25,
+            kind="volatile",
+            coupling_fn="gelu",
+            tonic_volatility=-3.0,
+        )
+        d = original.to_dict()
+        restored = LayerConfig.from_dict(d)
+        assert restored.size == original.size
+        assert restored.kind == original.kind
+        assert restored.coupling_fn == original.coupling_fn
+        assert restored.tonic_volatility == original.tonic_volatility
+
+
+class TestResolveCouplingFn:
+    """Test coupling function name resolution."""
+
+    def test_resolve_coupling_fn_from_string_gelu(self):
+        """Resolve 'gelu' string to jax.nn.gelu."""
+        fn = resolve_coupling_fn("gelu")
+        assert fn is jax.nn.gelu
+
+    def test_resolve_coupling_fn_from_string_relu(self):
+        """Resolve 'relu' string to jax.nn.relu."""
+        fn = resolve_coupling_fn("relu")
+        assert fn is jax.nn.relu
+
+    def test_resolve_coupling_fn_from_string_identity(self):
+        """Resolve 'identity' string to identity function."""
+        fn = resolve_coupling_fn("identity")
+        import jax.numpy as jnp
+
+        x = jnp.array([1.0, 2.0])
+        result = fn(x)
+        assert jnp.allclose(result, x)
+
+    def test_resolve_coupling_fn_from_string_unknown_raises(self):
+        """Unknown string name raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown coupling function"):
+            resolve_coupling_fn("unknown_fn")
+
+    def test_resolve_coupling_fn_from_callable_returns_it(self):
+        """Callable is returned as-is."""
+        fn = lambda x: x * 2
+        result = resolve_coupling_fn(fn)
+        assert result is fn
+
+    def test_resolve_coupling_fn_from_none_returns_none(self):
+        """None returns None."""
+        assert resolve_coupling_fn(None) is None
+
+    def test_resolve_coupling_fn_from_invalid_type_raises(self):
+        """Invalid type raises TypeError."""
+        with pytest.raises(TypeError):
+            resolve_coupling_fn(123)
+
+
+class TestDeepNetworkFromConfigs:
+    """Test DeepNetwork.from_configs() factory."""
+
+    def test_from_configs_basic(self):
+        """Build a basic network from configs."""
+        configs = [
+            LayerConfig(size=10),
+            LayerConfig(size=20),
+            LayerConfig(size=15),
+        ]
+        net = DeepNetwork.from_configs(configs)
+        assert net.n_layers == 3
+        assert net.layer_sizes == [10, 20, 15]
+
+    def test_from_configs_with_network_coupling_fn_string(self):
+        """Network-level coupling function can be a string."""
+        configs = [
+            LayerConfig(size=10),
+            LayerConfig(size=20),
+        ]
+        net = DeepNetwork.from_configs(configs, coupling_fn="gelu")
+        assert net.n_layers == 2
+        # Verify the network was built successfully
+        assert net.state is not None
+
+    def test_from_configs_with_network_coupling_fn_callable(self):
+        """Network-level coupling function can be a callable."""
+        configs = [
+            LayerConfig(size=10),
+            LayerConfig(size=20),
+        ]
+        net = DeepNetwork.from_configs(configs, coupling_fn=jax.nn.relu)
+        assert net.n_layers == 2
+
+    def test_from_configs_with_per_layer_coupling_fn(self):
+        """Per-layer coupling functions override network-level."""
+        configs = [
+            LayerConfig(size=10),
+            LayerConfig(size=20, coupling_fn="gelu"),
+        ]
+        net = DeepNetwork.from_configs(configs, coupling_fn="relu")
+        assert net.n_layers == 2
+        # Layer 1 has gelu (from config), layer 0 has relu (from network)
+        # This is tested implicitly through successful build
+
+    def test_from_configs_with_layer_params_override(self):
+        """Per-layer parameter overrides are applied."""
+        configs = [
+            LayerConfig(size=10, tonic_volatility=-2.0),
+            LayerConfig(size=20),
+        ]
+        net = DeepNetwork.from_configs(configs)
+        assert net.n_layers == 2
+        # Verify state was initialized
+        assert net.state is not None
+
+    def test_from_configs_empty_raises(self):
+        """Empty configs list raises ValueError."""
+        with pytest.raises(ValueError):
+            DeepNetwork.from_configs([])
+
+    def test_from_configs_method_chaining_equivalent(self):
+        """from_configs produces same result as method chaining."""
+        # Build with chaining
+        net1 = DeepNetwork().add_layer(size=10).add_layer(size=20).add_layer(size=15)
+
+        # Build with from_configs
+        configs = [
+            LayerConfig(size=10),
+            LayerConfig(size=20),
+            LayerConfig(size=15),
+        ]
+        net2 = DeepNetwork.from_configs(configs)
+
+        # Both should have same structure
+        assert net1.n_layers == net2.n_layers
+        assert net1.layer_sizes == net2.layer_sizes
+
+
+class TestDeepNetworkFromDict:
+    """Test DeepNetwork.from_dict() factory."""
+
+    def test_from_dict_basic(self):
+        """Build a network from a dictionary config."""
+        config = {
+            "layers": [
+                {"size": 10},
+                {"size": 20},
+                {"size": 15},
+            ]
+        }
+        net = DeepNetwork.from_dict(config)
+        assert net.n_layers == 3
+        assert net.layer_sizes == [10, 20, 15]
+
+    def test_from_dict_with_network_coupling_fn(self):
+        """Network-level coupling function from dict."""
+        config = {
+            "layers": [
+                {"size": 10},
+                {"size": 20},
+            ],
+            "coupling_fn": "gelu",
+        }
+        net = DeepNetwork.from_dict(config)
+        assert net.n_layers == 2
+
+    def test_from_dict_with_per_layer_coupling_fn(self):
+        """Per-layer coupling functions in dict."""
+        config = {
+            "layers": [
+                {"size": 10},
+                {"size": 20, "coupling_fn": "gelu"},
+                {"size": 15},
+            ]
+        }
+        net = DeepNetwork.from_dict(config)
+        assert net.n_layers == 3
+
+    def test_from_dict_with_network_params(self):
+        """Network-level parameters from dict."""
+        config = {
+            "layers": [
+                {"size": 10},
+                {"size": 20},
+            ],
+            "volatility_updates": "standard",
+            "max_posterior_precision": 1e8,
+        }
+        net = DeepNetwork.from_dict(config)
+        assert net.volatility_updates == "standard"
+        assert net.max_posterior_precision == 1e8
+
+    def test_from_dict_missing_layers_raises(self):
+        """Missing 'layers' key raises ValueError."""
+        config = {"coupling_fn": "gelu"}
+        with pytest.raises(ValueError, match="'layers'"):
+            DeepNetwork.from_dict(config)
+
+    def test_from_dict_empty_layers_raises(self):
+        """Empty 'layers' list raises ValueError."""
+        config = {"layers": []}
+        with pytest.raises(ValueError, match="not be empty"):
+            DeepNetwork.from_dict(config)
+
+    def test_from_dict_ignores_unknown_keys(self):
+        """Unknown keys in dict are ignored."""
+        config = {
+            "layers": [
+                {"size": 10},
+                {"size": 20},
+            ],
+            "unknown_key": "ignored",
+            "another_unknown": 123,
+        }
+        net = DeepNetwork.from_dict(config)
+        assert net.n_layers == 2
+
+    def test_from_dict_json_round_trip(self):
+        """Configs can be serialized to JSON and back."""
+        config = {
+            "layers": [
+                {"size": 10},
+                {"size": 20, "coupling_fn": "gelu"},
+                {"size": 15},
+            ],
+            "coupling_fn": "identity",
+            "volatility_updates": "unbounded",
+        }
+
+        # Serialize to JSON
+        json_str = json.dumps(config)
+
+        # Deserialize from JSON
+        loaded_config = json.loads(json_str)
+
+        # Build from loaded config
+        net = DeepNetwork.from_dict(loaded_config)
+        assert net.n_layers == 3
+        assert net.layer_sizes == [10, 20, 15]
+
+    def test_from_dict_layer_config_objects(self):
+        """from_dict accepts LayerConfig objects in 'layers'."""
+        configs_obj = [
+            LayerConfig(size=10),
+            LayerConfig(size=20, coupling_fn="gelu"),
+        ]
+        config = {"layers": configs_obj}
+
+        net = DeepNetwork.from_dict(config)
+        assert net.n_layers == 2
+
+
+class TestDeclarativeWorkflows:
+    """Test realistic workflows with declarative API."""
+
+    def test_hyperparameter_sweep_simulation(self):
+        """Simulate a hyperparameter sweep."""
+        layer_sizes = [
+            [10, 20],
+            [10, 30],
+            [15, 20],
+        ]
+
+        networks = []
+        for sizes in layer_sizes:
+            config = {"layers": [{"size": s} for s in sizes]}
+            net = DeepNetwork.from_dict(config)
+            networks.append(net)
+
+        assert len(networks) == 3
+        assert networks[0].layer_sizes == [10, 20]
+        assert networks[1].layer_sizes == [10, 30]
+        assert networks[2].layer_sizes == [15, 20]
+
+    def test_reproducibility_via_config_dict(self):
+        """Two networks built from the same dict config are equivalent."""
+        config = {
+            "layers": [
+                {"size": 10},
+                {"size": 20, "coupling_fn": "gelu"},
+                {"size": 15},
+            ],
+            "coupling_fn": "identity",
+        }
+
+        net1 = DeepNetwork.from_dict(config)
+        net2 = DeepNetwork.from_dict(config)
+
+        assert net1.n_layers == net2.n_layers
+        assert net1.layer_sizes == net2.layer_sizes
+        # Both should be independently usable
+        assert net1.state is not None
+        assert net2.state is not None
+
+    def test_backward_compatible_with_chaining(self):
+        """Existing code using method chaining still works."""
+        net = DeepNetwork().add_layer(size=10).add_layer(size=20).add_layer(size=15)
+        assert net.n_layers == 3
+        assert net.layer_sizes == [10, 20, 15]

--- a/tests/test_deepnetwork.py
+++ b/tests/test_deepnetwork.py
@@ -766,3 +766,368 @@ def test_constant_input_is_linearly_coupled():
 
     expected = w1 @ jax.nn.gelu(w2 @ x + b2) + b1
     np.testing.assert_allclose(net.predict(x), expected, rtol=1e-5, atol=1e-6)
+
+
+def _set_weights(net: DeepNetwork, weights: dict) -> DeepNetwork:
+    """Replace ``weights_in`` on the given layers (index -> matrix)."""
+    elements = list(net.state.layers)
+    for i, w in weights.items():
+        elements[i] = dataclasses.replace(elements[i], weights_in=jnp.asarray(w))
+    net.state = dataclasses.replace(net.state, layers=tuple(elements))
+    return net
+
+
+def _norm_rel_err(a, b) -> float:
+    """Relative error between two arrays, measured in the Frobenius norm."""
+    return float(jnp.linalg.norm(a - b) / jnp.linalg.norm(b))
+
+
+def test_input_error_routes_child_error_through_weights():
+    """``input_error()`` returns the child's error routed back through the weights.
+
+    Two linear layers without bias and with default (unit) precisions: the
+    confidence weighting is 1, so the message at the input (top) layer reduces
+    to ``W.T @ (y - W @ x)`` — the output residual multiplied back through the
+    connecting weight matrix.
+    """
+    rng = np.random.default_rng(1)
+    w = rng.normal(size=(3, 2))
+    x = jnp.asarray(rng.normal(size=(2,)))
+    y = jnp.asarray(rng.normal(size=(3,)))
+
+    net = (
+        DeepNetwork()
+        .add_layer(size=3, add_constant_input=False)
+        .add_layer(size=2, add_constant_input=False)
+    )
+    _set_weights(net, {1: w})
+    net.prediction(x).update(y)
+
+    expected = jnp.asarray(w).T @ (y - jnp.asarray(w) @ x)
+    np.testing.assert_allclose(net.input_error(), expected, rtol=1e-5, atol=1e-6)
+
+
+# Feed-forward block used by the backprop-parity tests below:
+# a Linear -> GELU -> Linear network, D -> H -> D, without biases.
+_FF_D, _FF_H = 8, 16
+
+
+def _ff_oracle_grads(w1, w2, x, y):
+    """Backprop gradients of the squared-error loss on the same forward pass.
+
+    The forward function mirrors the DeepNetwork exactly: the top (input)
+    layer predicts the hidden layer linearly, and the hidden layer predicts
+    the output layer through the GELU coupling.
+    """
+
+    def loss(w1_, w2_, x_):
+        return 0.5 * jnp.sum((y - w1_ @ jax.nn.gelu(w2_ @ x_)) ** 2)
+
+    return jax.grad(loss, argnums=(0, 1, 2))(w1, w2, x)
+
+
+def _ff_net(hidden_kwargs: dict, top_kwargs: dict, leaf_kwargs: dict) -> DeepNetwork:
+    return (
+        DeepNetwork()
+        .add_layer(size=_FF_D, add_constant_input=False, **leaf_kwargs)
+        .add_layer(
+            size=_FF_H,
+            add_constant_input=False,
+            coupling_fn=jax.nn.gelu,
+            **hidden_kwargs,
+        )
+        .add_layer(size=_FF_D, add_constant_input=False, **top_kwargs)
+    )
+
+
+def test_ff_block_single_sweep_matches_backprop():
+    """One local learning step on Linear -> GELU -> Linear matches backprop.
+
+    The network is configured so that the single belief-propagation sweep
+    reproduces the gradients of a squared-error loss on the identical forward
+    function: volatility levels frozen, high prior precision (confidence) on
+    the hidden and input layers so their beliefs barely move during the update
+    sweep, unit precision on the observed output layer, and the
+    ``"precision_weighted"`` learning mode — the hidden layer's belief shift is
+    its routed error divided by its posterior precision, and the
+    precision-weighted gradient multiplies that same precision back in.
+
+    Bias columns are excluded: the prediction step applies the coupling
+    function to the constant bias node while the learning step treats it as
+    linear, so with biases the two sides compute different forward functions.
+
+    Measured agreement (norm-relative): ~5e-4 on the weight gradients and
+    ~2e-3 on the input error message in float32; better than 1e-5 in float64.
+    """
+    rng = np.random.default_rng(42)
+    w1 = jnp.asarray(rng.normal(size=(_FF_D, _FF_H)) * (2.0 / _FF_H) ** 0.5)
+    w2 = jnp.asarray(rng.normal(size=(_FF_H, _FF_D)) * (2.0 / _FF_D) ** 0.5)
+    x = jnp.asarray(rng.normal(size=(_FF_D,)))
+    y = jnp.asarray(w1 @ jax.nn.gelu(w2 @ x) + rng.normal(size=(_FF_D,)))
+
+    g_w1, g_w2, g_x = _ff_oracle_grads(w1, w2, x, y)
+
+    high_confidence = dict(
+        volatility_parent=False,
+        tonic_volatility=-20.0,
+        precision=1e4,
+        expected_precision=1e4,
+    )
+    net = _ff_net(
+        hidden_kwargs=high_confidence,
+        top_kwargs=high_confidence,
+        leaf_kwargs=dict(volatility_parent=False, tonic_volatility=-20.0),
+    )
+    _set_weights(net, {1: w1, 2: w2})
+
+    lr = 1e-3
+    net.prediction(x).update(
+        y, optimizer=optax.sgd(lr), learning_kind="precision_weighted"
+    )
+
+    # The applied weight change divided by -lr is the descent gradient.
+    d_w1 = -(net.state.layers[1].weights_in - w1) / lr
+    d_w2 = -(net.state.layers[2].weights_in - w2) / lr
+
+    assert _norm_rel_err(d_w1, g_w1) < 1e-2
+    assert _norm_rel_err(d_w2, g_w2) < 1e-2
+    # Prediction errors follow the observed-minus-predicted convention, so the
+    # input message is the negative of the loss gradient at the input.
+    assert _norm_rel_err(net.input_error(), -g_x) < 1e-2
+
+
+def test_input_side_gradient_precision_cancellation():
+    """The input-side weight gradient equals backprop at default settings.
+
+    The hidden layer's posterior mean shift is its routed error divided by its posterior
+    precision; the ``"precision_weighted"`` gradient multiplies the resulting prediction
+    error by that same posterior precision. The division cancels exactly, so the
+    gradient of the weight matrix entering the top (input) layer matches backprop at any
+    precision setting — checked here with all defaults.
+    """
+    rng = np.random.default_rng(7)
+    w1 = jnp.asarray(rng.normal(size=(_FF_D, _FF_H)) * (2.0 / _FF_H) ** 0.5)
+    w2 = jnp.asarray(rng.normal(size=(_FF_H, _FF_D)) * (2.0 / _FF_D) ** 0.5)
+    x = jnp.asarray(rng.normal(size=(_FF_D,)))
+    y = jnp.asarray(w1 @ jax.nn.gelu(w2 @ x) + rng.normal(size=(_FF_D,)))
+
+    _, g_w2, _ = _ff_oracle_grads(w1, w2, x, y)
+
+    net = _ff_net(hidden_kwargs={}, top_kwargs={}, leaf_kwargs={})
+    _set_weights(net, {1: w1, 2: w2})
+
+    lr = 1e-3
+    net.prediction(x).update(
+        y, optimizer=optax.sgd(lr), learning_kind="precision_weighted"
+    )
+    d_w2 = -(net.state.layers[2].weights_in - w2) / lr
+
+    assert _norm_rel_err(d_w2, g_w2) < 1e-3
+
+
+def _ff_net_with_weights(rng) -> tuple[DeepNetwork, jnp.ndarray, jnp.ndarray]:
+    """Build a default-config feed-forward net with random weights, plus the weights."""
+    w1 = jnp.asarray(rng.normal(size=(_FF_D, _FF_H)) * (2.0 / _FF_H) ** 0.5)
+    w2 = jnp.asarray(rng.normal(size=(_FF_H, _FF_D)) * (2.0 / _FF_D) ** 0.5)
+    net = _ff_net(hidden_kwargs={}, top_kwargs={}, leaf_kwargs={})
+    _set_weights(net, {1: w1, 2: w2})
+    return net, w1, w2
+
+
+def test_sample_step_matches_stateful_api():
+    """The pure per-sample step reproduces the stateful prediction/update path.
+
+    From the same state template, ``sample_step`` must return (a) the same input-layer
+    error as ``net.prediction(x).update(y)`` followed by ``input_error()``, (b)
+    confidence increments equal to the change of the carried fields (value precision and
+    the volatility level), and (c) weight gradients matching the weight change one SGD
+    step applies.
+    """
+    from pyhgf.utils.vectorized_belief_propagation import sample_step
+
+    rng = np.random.default_rng(11)
+    x = jnp.asarray(rng.normal(size=(_FF_D,)))
+    y = jnp.asarray(rng.normal(size=(_FF_D,)))
+
+    net, w1, w2 = _ff_net_with_weights(rng)
+    template = net.state
+
+    input_error, grads, increments = sample_step(template, x, y)
+
+    # Beliefs-only stateful pass: input error and confidence increments.
+    net.prediction(x).update(y)
+    np.testing.assert_allclose(input_error, net.input_error(), rtol=1e-5, atol=1e-7)
+    for elem_before, elem_after, inc in zip(
+        template.layers, net.state.layers, increments
+    ):
+        for field in ("precision", "mean_vol", "precision_vol"):
+            np.testing.assert_allclose(
+                inc[field],
+                getattr(elem_after.state, field) - getattr(elem_before.state, field),
+                rtol=1e-5,
+                atol=1e-6,
+            )
+
+    # Learning stateful pass: gradients match the applied weight change.
+    lr = 1e-3
+    net_learn = _ff_net(hidden_kwargs={}, top_kwargs={}, leaf_kwargs={})
+    _set_weights(net_learn, {1: w1, 2: w2})
+    net_learn.prediction(x).update(
+        y, optimizer=optax.sgd(lr), learning_kind="precision_weighted"
+    )
+    # atol: reconstructing the gradient from a float32 weight delta of ~lr·grad
+    # loses ~(weight magnitude · float32 eps) / lr of absolute precision.
+    for k in (1, 2):
+        implied = (
+            -(net_learn.state.layers[k].weights_in - template.layers[k].weights_in) / lr
+        )
+        np.testing.assert_allclose(grads[k], implied, rtol=1e-3, atol=1e-4)
+
+
+def test_batch_update_averages_and_is_batch_size_invariant():
+    """A batch counts as one observation: averaged updates, repetition-invariant.
+
+    ``batch_update`` must apply the batch-mean of the per-sample weight gradients in one
+    optimiser step, advance the confidence state by the batch-mean of the per-sample
+    increments, and return per-sample input errors matching the pure per-sample step.
+    Feeding the same batch twice over must produce the same step.
+    """
+    from pyhgf.utils.vectorized_belief_propagation import sample_step
+
+    rng = np.random.default_rng(23)
+    batch = 4
+    xb = jnp.asarray(rng.normal(size=(batch, _FF_D)))
+    yb = jnp.asarray(rng.normal(size=(batch, _FF_D)))
+
+    net, w1, w2 = _ff_net_with_weights(rng)
+    template = net.state
+
+    # Per-sample reference quantities from the pure step.
+    ref = [sample_step(template, xb[i], yb[i]) for i in range(batch)]
+    mean_grads = {
+        k: jnp.mean(jnp.stack([r[1][k] for r in ref]), axis=0) for k in (1, 2)
+    }
+    mean_inc = jnp.mean(
+        jnp.stack([r[2][1]["precision"] for r in ref]), axis=0
+    )  # hidden-layer value precision
+
+    lr = 1e-2
+    net.batch_update(xb, yb, optimizer=optax.sgd(lr))
+
+    for k in (1, 2):
+        np.testing.assert_allclose(
+            net.state.layers[k].weights_in,
+            template.layers[k].weights_in - lr * mean_grads[k],
+            rtol=1e-5,
+            atol=1e-6,
+        )
+    np.testing.assert_allclose(
+        net.state.layers[1].state.precision,
+        template.layers[1].state.precision + mean_inc,
+        rtol=1e-5,
+        atol=1e-6,
+    )
+    assert net.input_errors.shape == (batch, _FF_D)
+    for i in range(batch):
+        np.testing.assert_allclose(net.input_errors[i], ref[i][0], rtol=1e-5, atol=1e-6)
+
+    # The same samples twice over: averaging makes the step identical.
+    net_twice = _ff_net(hidden_kwargs={}, top_kwargs={}, leaf_kwargs={})
+    _set_weights(net_twice, {1: w1, 2: w2})
+    net_twice.batch_update(
+        jnp.concatenate([xb, xb]), jnp.concatenate([yb, yb]), optimizer=optax.sgd(lr)
+    )
+    for k in (1, 2):
+        np.testing.assert_allclose(
+            net_twice.state.layers[k].weights_in,
+            net.state.layers[k].weights_in,
+            rtol=1e-6,
+            atol=1e-7,
+        )
+    np.testing.assert_allclose(
+        net_twice.state.layers[1].state.precision,
+        net.state.layers[1].state.precision,
+        rtol=1e-6,
+        atol=1e-7,
+    )
+
+
+def test_batch_update_freezing_flags():
+    """``update_confidences=False`` and ``optimizer=None`` freeze their targets.
+
+    Without confidence updates, the carried fields stay exactly at their template values
+    while the weights still learn (the mode used for exact comparisons against
+    backpropagation). Without an optimiser, the weights stay exactly fixed while the
+    confidences still adapt.
+    """
+    rng = np.random.default_rng(31)
+    xb = jnp.asarray(rng.normal(size=(4, _FF_D)))
+    yb = jnp.asarray(rng.normal(size=(4, _FF_D)))
+
+    # Confidences frozen, weights learning.
+    net, w1, w2 = _ff_net_with_weights(rng)
+    template = net.state
+    net.batch_update(xb, yb, optimizer=optax.sgd(1e-2), update_confidences=False)
+    for elem_before, elem_after in zip(template.layers, net.state.layers):
+        for field in ("precision", "mean_vol", "precision_vol"):
+            np.testing.assert_array_equal(
+                getattr(elem_after.state, field), getattr(elem_before.state, field)
+            )
+    assert not np.allclose(net.state.layers[1].weights_in, w1)
+
+    # Weights frozen, confidences adapting.
+    net_frozen = _ff_net(hidden_kwargs={}, top_kwargs={}, leaf_kwargs={})
+    _set_weights(net_frozen, {1: w1, 2: w2})
+    template_frozen = net_frozen.state
+    net_frozen.batch_update(xb, yb)
+    np.testing.assert_array_equal(net_frozen.state.layers[1].weights_in, w1)
+    assert not np.allclose(
+        net_frozen.state.layers[1].state.precision,
+        template_frozen.layers[1].state.precision,
+    )
+
+
+def test_batch_update_from_predicted_states_matches():
+    """Reusing the forward sweep's states gives the same step as re-sweeping.
+
+    ``predict_states`` + ``batch_update(predicted=...)`` must produce the same new
+    weights and per-sample input errors as the plain call, which re-runs the forward
+    sweep internally — the reuse reorganises when the same computation happens, it does
+    not change the computation.
+    """
+    rng = np.random.default_rng(17)
+    w1 = jnp.asarray(rng.normal(size=(_FF_D, _FF_H)) * (2.0 / _FF_H) ** 0.5)
+    w2 = jnp.asarray(rng.normal(size=(_FF_H, _FF_D)) * (2.0 / _FF_D) ** 0.5)
+    xb = jnp.asarray(rng.normal(size=(5, _FF_D)))
+    yb = jnp.asarray(rng.normal(size=(5, _FF_D)))
+
+    def fresh():
+        net = _ff_net(hidden_kwargs={}, top_kwargs={}, leaf_kwargs={})
+        return _set_weights(net, {1: w1, 2: w2})
+
+    plain = fresh()
+    np.testing.assert_allclose(
+        fresh().predict_states(xb)[0], plain.predict(xb), rtol=1e-6, atol=1e-7
+    )
+    plain.batch_update(xb, yb, optimizer=optax.sgd(1e-2))
+
+    reused = fresh()
+    _, states = reused.predict_states(xb)
+    reused.batch_update(xb, yb, optimizer=optax.sgd(1e-2), predicted=states)
+
+    for k in (1, 2):
+        np.testing.assert_allclose(
+            reused.state.layers[k].weights_in,
+            plain.state.layers[k].weights_in,
+            rtol=1e-6,
+            atol=1e-7,
+        )
+    np.testing.assert_allclose(
+        reused.input_errors, plain.input_errors, rtol=1e-6, atol=1e-7
+    )
+    np.testing.assert_allclose(
+        reused.state.layers[1].state.precision,
+        plain.state.layers[1].state.precision,
+        rtol=1e-6,
+        atol=1e-7,
+    )

--- a/tests/test_fused.py
+++ b/tests/test_fused.py
@@ -1,0 +1,181 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+from jax import random
+
+from pyhgf.model import (
+    DeepNetworkAdapter,
+    FusedPipeline,
+    from_embedding,
+    from_feedforward,
+    from_linear,
+    hybrid_from_gpt,
+)
+
+# The executor's gates, verified against
+# automatic differentiation on the same forward functions — autodiff appears
+# here ONLY as a test oracle; the pipeline itself never uses it. The
+# single-part gate is here; the mixed-block gate lives in test_hybrid.py and
+# the full-model gradient gates in test_transformer.py.
+
+_PARITY = dict(
+    volatility_parent=False,
+    tonic_volatility=-20.0,
+    precision=1e4,
+    expected_precision=1e4,
+)
+_PARITY_LEAF = dict(volatility_parent=False, tonic_volatility=-20.0)
+
+
+def _norm_rel(a, b) -> float:
+    return float(jnp.linalg.norm(a - b) / jnp.linalg.norm(b))
+
+
+def test_fused_adapter_tracks_backprop_twin():
+    """A single learning part tracks an SGD backprop twin, step for step.
+
+    A biased feed-forward network in the parity configuration, trained by the
+    fused executor for three steps, must follow a twin trained by autodiff
+    SGD on the identical forward function: same weights (bias columns
+    included) after every step, and the same per-sample input errors.
+    """
+    rng = np.random.default_rng(0)
+    d, h, batch, lr = 6, 12, 5, 1e-3
+    k1, k2 = random.split(random.key(1))
+    fc1 = eqx.nn.Linear(d, h, key=k1)
+    fc2 = eqx.nn.Linear(h, d, key=k2)
+
+    part = DeepNetworkAdapter(
+        from_feedforward(fc1, fc2, leaf_kwargs=_PARITY_LEAF, layer_kwargs=_PARITY),
+        optimizer=optax.sgd(lr),
+        learning_kind="precision_weighted",
+    )
+    fused = FusedPipeline(part)
+
+    # The twin: the same folded [W | b] blocks, trained by autodiff.
+    w1b = jnp.concatenate([fc1.weight, fc1.bias[:, None]], axis=1)
+    w2b = jnp.concatenate([fc2.weight, fc2.bias[:, None]], axis=1)
+
+    def forward(w1b_, w2b_, row):
+        hidden = w1b_[:, :-1] @ row + w1b_[:, -1]
+        return w2b_[:, :-1] @ jax.nn.gelu(hidden) + w2b_[:, -1]
+
+    for step in range(3):
+        xb = jnp.asarray(rng.normal(size=(batch, d)))
+        yb = jnp.asarray(rng.normal(size=(batch, d)))
+
+        def mean_loss(w1b_, w2b_):
+            out = jax.vmap(lambda row: forward(w1b_, w2b_, row))(xb)
+            return jnp.mean(jnp.sum(0.5 * (yb - out) ** 2, axis=-1))
+
+        g_w1b, g_w2b = jax.grad(mean_loss, argnums=(0, 1))(w1b, w2b)
+        per_sample_dx = jax.vmap(
+            lambda x_row, y_row: jax.grad(
+                lambda a: jnp.sum(0.5 * (y_row - forward(w1b, w2b, a)) ** 2)
+            )(x_row)
+        )(xb, yb)
+
+        _, input_error = fused.step(xb, yb)
+        w1b = w1b - lr * g_w1b
+        w2b = w2b - lr * g_w2b
+
+        fused.merge()
+        assert _norm_rel(part.net.state.layers[2].weights_in, w1b) < 1e-4, f"{step}"
+        assert _norm_rel(part.net.state.layers[1].weights_in, w2b) < 1e-4, f"{step}"
+        assert _norm_rel(input_error, per_sample_dx) < 1e-2, f"step {step}"
+
+
+def test_fused_confidences_carry_across_steps():
+    """Released confidences adapt across steps; pinned ones stay put."""
+    rng = np.random.default_rng(2)
+    k1, k2 = random.split(random.key(3))
+    fc1 = eqx.nn.Linear(6, 12, key=k1)
+    fc2 = eqx.nn.Linear(12, 6, key=k2)
+
+    def run(update_confidences):
+        leaf = _PARITY_LEAF if not update_confidences else {}
+        layer = (
+            _PARITY
+            if not update_confidences
+            else dict(precision=30.0, expected_precision=30.0)
+        )
+        part = DeepNetworkAdapter(
+            from_feedforward(fc1, fc2, leaf_kwargs=leaf, layer_kwargs=layer),
+            optimizer=optax.adam(1e-3),
+            update_confidences=update_confidences,
+        )
+        fused = FusedPipeline(part)
+        before = fused.state[0].layers[1].state.precision
+        for _ in range(3):
+            fused.step(
+                jnp.asarray(rng.normal(size=(4, 6))),
+                jnp.asarray(rng.normal(size=(4, 6))),
+            )
+        return before, fused.state[0].layers[1].state.precision
+
+    before, after = run(update_confidences=True)
+    assert not jnp.allclose(before, after)  # the confidence state moved
+    before, after = run(update_confidences=False)
+    np.testing.assert_allclose(before, after)  # pinned for parity
+
+
+def test_fused_merge_writes_state_back():
+    """``merge`` puts the advanced state back onto the wrapped parts."""
+    rng = np.random.default_rng(6)
+    k1, k2 = random.split(random.key(7))
+    fc1 = eqx.nn.Linear(6, 12, key=k1)
+    fc2 = eqx.nn.Linear(12, 6, key=k2)
+    adapter = DeepNetworkAdapter(
+        from_feedforward(fc1, fc2, leaf_kwargs=_PARITY_LEAF, layer_kwargs=_PARITY),
+        optimizer=optax.adam(1e-3),
+    )
+    before = adapter.net.state.layers[1].weights_in
+    fused = FusedPipeline(adapter)
+    fused.step(
+        jnp.asarray(rng.normal(size=(4, 6))), jnp.asarray(rng.normal(size=(4, 6)))
+    )
+    assert jnp.allclose(adapter.net.state.layers[1].weights_in, before)  # untouched
+    fused.merge()
+    assert not jnp.allclose(adapter.net.state.layers[1].weights_in, before)
+    assert adapter.net.opt_state is fused.state[1]
+
+
+def test_fused_predict_is_read_only():
+    """``predict`` returns the forward pass and advances nothing."""
+    rng = np.random.default_rng(8)
+    k1, k2 = random.split(random.key(9))
+    fc1 = eqx.nn.Linear(6, 12, key=k1)
+    fc2 = eqx.nn.Linear(12, 6, key=k2)
+    adapter = DeepNetworkAdapter(
+        from_feedforward(fc1, fc2, leaf_kwargs=_PARITY_LEAF, layer_kwargs=_PARITY),
+        optimizer=optax.adam(1e-3),
+    )
+    fused = FusedPipeline(adapter)
+    x = jnp.asarray(rng.normal(size=(4, 6)))
+
+    state_before = fused.state
+    out = fused.predict(x)
+    assert fused.state is state_before
+    oracle = jax.vmap(lambda row: fc2(jax.nn.gelu(fc1(row))))(x)
+    np.testing.assert_allclose(out, oracle, rtol=1e-4, atol=1e-5)
+
+
+def test_fused_rejects_unsupported_parts():
+    """Part types outside the supported set are refused, and say so."""
+    from pyhgf.model import PCModule
+
+    class Opaque(PCModule):
+        """Custom PCModule that isn't a recognized executor type."""
+
+        def __init__(self):
+            pass
+
+        def init_state(self):
+            return ()
+
+    with np.testing.assert_raises(NotImplementedError):
+        FusedPipeline(Opaque())

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -1,0 +1,206 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+import dataclasses
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+
+from pyhgf.model import (
+    DeepNetwork,
+    DeepNetworkAdapter,
+    FusedPipeline,
+    PCSequential,
+    Residual,
+    gelu_adapter,
+    layer_norm_adapter,
+)
+
+# Automatic differentiation appears in this file ONLY as a test oracle: the
+# hand-derived backward formulas and the pipeline's error routing must match
+# what autodiff computes on the same forward functions. The pipeline itself
+# never uses autodiff.
+
+
+def _random_layer_norm(dim: int, rng) -> eqx.nn.LayerNorm:
+    """Build an ``eqx.nn.LayerNorm`` with non-trivial scale and shift."""
+    ln = eqx.nn.LayerNorm(dim)
+    ln = eqx.tree_at(lambda m: m.weight, ln, jnp.asarray(rng.normal(size=(dim,)) + 1.0))
+    ln = eqx.tree_at(lambda m: m.bias, ln, jnp.asarray(rng.normal(size=(dim,)) * 0.3))
+    return ln
+
+
+def test_gelu_backward_matches_autodiff():
+    """The hand-derived GELU backward equals the autodiff of the same forward."""
+    rng = np.random.default_rng(0)
+    x = jnp.asarray(rng.normal(size=(5, 7)))
+    error = jnp.asarray(rng.normal(size=(5, 7)))
+
+    part = gelu_adapter()
+    y, cache = part.forward_fn(x)
+    np.testing.assert_allclose(y, jax.nn.gelu(x), rtol=1e-6)
+
+    _, vjp = jax.vjp(jax.nn.gelu, x)
+    np.testing.assert_allclose(
+        part.backward_fn(cache, error), vjp(error)[0], rtol=1e-5, atol=1e-6
+    )
+
+
+def test_layer_norm_backward_matches_autodiff():
+    """The hand-derived LayerNorm backward equals the autodiff of the same forward."""
+    rng = np.random.default_rng(1)
+    dim = 6
+    ln = _random_layer_norm(dim, rng)
+    x = jnp.asarray(rng.normal(size=(4, dim)))
+    error = jnp.asarray(rng.normal(size=(4, dim)))
+
+    part = layer_norm_adapter(ln)
+    y, cache = part.forward_fn(x)
+    np.testing.assert_allclose(y, jax.vmap(ln)(x), rtol=1e-5, atol=1e-6)
+
+    _, vjp = jax.vjp(lambda a: jax.vmap(ln)(a), x)
+    np.testing.assert_allclose(
+        part.backward_fn(cache, error), vjp(error)[0], rtol=1e-4, atol=1e-5
+    )
+
+
+def _parity_ff_net(d: int, h: int, w1: jnp.ndarray, w2: jnp.ndarray) -> DeepNetwork:
+    """Build a Linear-GELU-Linear DeepNetwork in backprop-parity configuration.
+
+    Bias-free, volatility frozen, high prior confidence on the hidden and input layers,
+    unit precision on the observed output layer.
+    """
+    high_confidence = dict(
+        volatility_parent=False,
+        tonic_volatility=-20.0,
+        precision=1e4,
+        expected_precision=1e4,
+    )
+    net = (
+        DeepNetwork()
+        .add_layer(
+            size=d,
+            add_constant_input=False,
+            volatility_parent=False,
+            tonic_volatility=-20.0,
+        )
+        .add_layer(
+            size=h,
+            add_constant_input=False,
+            coupling_fn=jax.nn.gelu,
+            **high_confidence,
+        )
+        .add_layer(size=d, add_constant_input=False, **high_confidence)
+    )
+    elements = list(net.state.layers)
+    elements[1] = dataclasses.replace(elements[1], weights_in=w1)
+    elements[2] = dataclasses.replace(elements[2], weights_in=w2)
+    net.state = dataclasses.replace(net.state, layers=tuple(elements))
+    return net
+
+
+def test_mixed_pipeline_block_matches_backprop():
+    """A Transformer sub-block with mixed parts learns like backpropagation.
+
+    The block is ``output = x + FF(LayerNorm(x))`` — a frozen LayerNorm
+    (hand-derived backward), a PyHGF feed-forward in the parity
+    configuration, and a residual shortcut, run by the fused executor. One
+    training step against squared-error targets must (a) reproduce the
+    composed forward function exactly, (b) update the feed-forward weights by
+    the batch-averaged backprop gradient, and (c) return the loss gradient at
+    the block's *input* — which exercises the residual copy-and-add, the
+    LayerNorm formula, and both error-convention conversions in one pass.
+    """
+    rng = np.random.default_rng(42)
+    d, h, batch = 8, 16, 6
+
+    w1 = jnp.asarray(rng.normal(size=(d, h)) * (2.0 / h) ** 0.5)
+    w2 = jnp.asarray(rng.normal(size=(h, d)) * (2.0 / d) ** 0.5)
+    ln = _random_layer_norm(d, rng)
+    xb = jnp.asarray(rng.normal(size=(batch, d)))
+    yb = jnp.asarray(rng.normal(size=(batch, d)))
+
+    # --- Oracle: autodiff on the same composed forward function.
+    def block_fn(w1_, w2_, x_row):  # one sample
+        z = ln(x_row)
+        return x_row + w1_ @ jax.nn.gelu(w2_ @ z)
+
+    def mean_loss(w1_, w2_):
+        out = jax.vmap(lambda x_row: block_fn(w1_, w2_, x_row))(xb)
+        return jnp.mean(jnp.sum(0.5 * (yb - out) ** 2, axis=-1))
+
+    g_w1, g_w2 = jax.grad(mean_loss, argnums=(0, 1))(w1, w2)
+    # Per-sample loss gradient at the block input (the message the block
+    # should emit).
+    per_sample_dx = jax.vmap(
+        lambda x_row, y_row: jax.grad(
+            lambda a: jnp.sum(0.5 * (y_row - block_fn(w1, w2, a)) ** 2)
+        )(x_row)
+    )(xb, yb)
+    out_oracle = jax.vmap(lambda x_row: block_fn(w1, w2, x_row))(xb)
+
+    # --- The mixed pipeline: one fused step; the default error_fn is
+    # ``output - target``, exactly the squared-error loss gradient.
+    lr = 1e-3
+    ff = DeepNetworkAdapter(
+        _parity_ff_net(d, h, w1, w2),
+        optimizer=optax.sgd(lr),
+        learning_kind="precision_weighted",
+    )
+    block = Residual(PCSequential([layer_norm_adapter(ln), ff]))
+    fused = FusedPipeline(block)
+
+    out, error_in = fused.step(xb, yb)
+    fused.merge()
+
+    # (a) Forward parity.
+    np.testing.assert_allclose(out, out_oracle, rtol=1e-4, atol=1e-5)
+
+    def norm_rel(a, b):
+        return float(jnp.linalg.norm(a - b) / jnp.linalg.norm(b))
+
+    # (b) The weights moved by the batch-averaged backprop gradient.
+    d_w1 = -(ff.net.state.layers[1].weights_in - w1) / lr
+    d_w2 = -(ff.net.state.layers[2].weights_in - w2) / lr
+    assert norm_rel(d_w1, g_w1) < 1e-2
+    assert norm_rel(d_w2, g_w2) < 1e-2
+    # (c) The emitted input error is the loss gradient at the input.
+    assert norm_rel(error_in, per_sample_dx) < 1e-2
+
+
+def test_step_report_collects_update_and_error_norms():
+    """``step_report`` finds learning parts and reports their step magnitudes.
+
+    A two-part pipeline (frozen LayerNorm around a learning feed-forward)
+    behind a shortcut junction: after one training step, the report contains
+    exactly one entry — the learning part — with positive update and error
+    norms and its path inside the model.
+    """
+    from pyhgf.model import from_feedforward, step_report
+
+    rng = np.random.default_rng(2)
+    d, h, batch = 6, 12, 4
+    k1, k2 = jax.random.split(jax.random.key(3))
+    fc1 = eqx.nn.Linear(d, h, key=k1)
+    fc2 = eqx.nn.Linear(h, d, key=k2)
+    ln = _random_layer_norm(d, rng)
+    x = jnp.asarray(rng.normal(size=(batch, d)))
+    target = jnp.asarray(rng.normal(size=(batch, d)))
+
+    ff = DeepNetworkAdapter(from_feedforward(fc1, fc2), optimizer=optax.sgd(1e-3))
+    block = Residual(PCSequential([layer_norm_adapter(ln), ff]))
+    fused = FusedPipeline(block)
+
+    assert step_report(fused) == []  # nothing has stepped yet
+
+    fused.step(x, target)
+
+    report = step_report(fused)
+    assert len(report) == 1
+    entry = report[0]
+    assert entry["part"] == "Residual.branch.parts[1]"
+    assert entry["layer_sizes"] == [d, h, d]
+    assert entry["update_norm"] > 0
+    assert entry["error_norm"] > 0

--- a/tests/test_pcmodule_state.py
+++ b/tests/test_pcmodule_state.py
@@ -1,0 +1,247 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+"""Tests for the PCModule protocol and the ``init_state()`` pytree contract.
+
+Validates that:
+1. PCModule protocol enforcement catches incomplete implementations
+2. Each part's ``init_state()`` returns the pytree the executor expects
+3. Composite parts (Sequential, Residual, attention, GPT) nest child states
+   in the right order
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import optax
+import pytest
+
+from pyhgf.model import (
+    DeepNetwork,
+    DeepNetworkAdapter,
+    EquinoxAdapter,
+    PCModule,
+    PCSequential,
+    Residual,
+    gelu_adapter,
+)
+from pyhgf.model.transformer import HybridGPT, MultiHeadAttention
+
+
+class TestPCModuleProtocol:
+    """Test PCModule protocol enforcement via __init_subclass__."""
+
+    def test_incomplete_subclass_missing_init(self):
+        """Subclass without __init__ raises TypeError at class definition."""
+        with pytest.raises(TypeError, match="must define __init__"):
+
+            class BadPart(PCModule):
+                def init_state(self):
+                    return ()
+
+    def test_incomplete_subclass_missing_init_state(self):
+        """Subclass without init_state raises TypeError at class definition."""
+        with pytest.raises(TypeError, match="must define init_state"):
+
+            class BadPart(PCModule):
+                def __init__(self):
+                    pass
+
+    def test_valid_subclass_passes(self):
+        """Complete subclass with __init__ and init_state passes validation."""
+
+        # This should not raise
+        class GoodPart(PCModule):
+            def __init__(self):
+                pass
+
+            def init_state(self):
+                return ()
+
+        assert issubclass(GoodPart, PCModule)
+
+
+class TestEquinoxAdapterState:
+    """Frozen parts hold no state."""
+
+    def test_init_state_is_empty_tuple(self):
+        """EquinoxAdapter.init_state() returns the empty pytree ()."""
+        assert gelu_adapter().init_state() == ()
+        adapter = EquinoxAdapter(
+            forward_fn=lambda x: (x, ()),
+            backward_fn=lambda cache, error: error,
+        )
+        assert adapter.init_state() == ()
+
+
+class TestDeepNetworkAdapterState:
+    """Learning parts hold (network, opt_state)."""
+
+    @pytest.fixture
+    def simple_network(self):
+        """Create a simple 2-layer network for testing."""
+        return (
+            DeepNetwork()
+            .add_layer(size=4)  # output
+            .add_layer(size=8)  # input
+        )
+
+    def test_init_state_without_layers_raises(self):
+        """init_state() on empty network raises ValueError."""
+        adapter = DeepNetworkAdapter(DeepNetwork())
+        with pytest.raises(ValueError, match="no layers yet"):
+            adapter.init_state()
+
+    def test_init_state_with_frozen_weights(self, simple_network):
+        """init_state() with optimizer=None has opt_state=None."""
+        network, opt_state = DeepNetworkAdapter(
+            simple_network, optimizer=None
+        ).init_state()
+        assert network is not None
+        assert opt_state is None
+
+    def test_init_state_with_optimizer(self, simple_network):
+        """init_state() with optimizer initializes opt_state."""
+        network, opt_state = DeepNetworkAdapter(
+            simple_network, optimizer=optax.sgd(0.1)
+        ).init_state()
+        assert network is not None
+        assert opt_state is not None
+
+    def test_network_state_structure(self, simple_network):
+        """The threaded network carries its layers."""
+        network, _ = DeepNetworkAdapter(simple_network).init_state()
+        assert hasattr(network, "layers")
+        assert len(network.layers) == 2
+
+
+class TestPCSequentialState:
+    """PCSequential returns a tuple of child states, in order."""
+
+    def test_init_state_single_part(self):
+        """Sequential with one part returns a 1-tuple."""
+        part = EquinoxAdapter(forward_fn=lambda x: (x, ()), backward_fn=lambda c, e: e)
+        state = PCSequential([part]).init_state()
+        assert state == ((),)
+
+    def test_init_state_multiple_parts(self):
+        """Sequential returns child states in part order."""
+        net = DeepNetwork().add_layer(4).add_layer(8)
+        parts = [
+            EquinoxAdapter(forward_fn=lambda x: (x, ()), backward_fn=lambda c, e: e),
+            DeepNetworkAdapter(net),
+            gelu_adapter(),
+        ]
+        state = PCSequential(parts).init_state()
+        assert len(state) == 3
+        assert state[0] == ()  # frozen
+        assert state[1][0] is net.state  # learning: (network, opt_state)
+        assert state[2] == ()  # frozen
+
+    def test_child_states_in_order(self):
+        """Child states are in the same order as parts."""
+        net1 = DeepNetwork().add_layer(4).add_layer(8)
+        net2 = DeepNetwork().add_layer(6).add_layer(10)
+        state = PCSequential([
+            DeepNetworkAdapter(net1),
+            DeepNetworkAdapter(net2),
+        ]).init_state()
+        assert state[0][0] is net1.state
+        assert state[1][0] is net2.state
+
+
+class TestResidualState:
+    """Residual passes its branch's state through unchanged."""
+
+    def test_init_state_wraps_branch_state(self):
+        """Residual returns the branch's state directly."""
+        net = DeepNetwork().add_layer(4).add_layer(8)
+        state = Residual(DeepNetworkAdapter(net)).init_state()
+        assert state[0] is net.state  # (network, opt_state)
+
+    def test_residual_with_sequential_branch(self):
+        """Residual wrapping a Sequential delegates to the chain's tuple."""
+        net = DeepNetwork().add_layer(4).add_layer(8)
+        seq = PCSequential([gelu_adapter(), DeepNetworkAdapter(net)])
+        state = Residual(seq).init_state()
+        assert len(state) == 2
+        assert state[0] == ()
+
+
+class TestMultiHeadAttentionState:
+    """Attention returns the (q, k, v, o) tuple of its weight tables."""
+
+    def test_init_state_collects_four_projections(self):
+        """Attention state aggregates Q, K, V, O parts."""
+        attn = MultiHeadAttention(
+            gelu_adapter(), gelu_adapter(), gelu_adapter(), gelu_adapter(), n_heads=8
+        )
+        assert attn.init_state() == ((), (), (), ())
+
+    def test_attention_with_mixed_frozen_learning(self):
+        """Attention can mix frozen and learning parts."""
+        net = DeepNetwork().add_layer(64).add_layer(64)
+        attn = MultiHeadAttention(
+            DeepNetworkAdapter(net),
+            gelu_adapter(),
+            gelu_adapter(),
+            gelu_adapter(),
+            n_heads=8,
+        )
+        q_state, k_state, v_state, o_state = attn.init_state()
+        assert q_state[0] is net.state  # learning: (network, opt_state)
+        assert (k_state, v_state, o_state) == ((), (), ())
+
+
+class TestHybridGPTState:
+    """HybridGPT returns (pipeline_state, token_state, position_state)."""
+
+    def test_init_state_frozen_embeddings(self):
+        """Frozen embeddings contribute empty states."""
+        gpt = HybridGPT(
+            tok_table=jnp.ones((256, 64)),
+            pos_table=jnp.ones((512, 64)),
+            pipeline=PCSequential([gelu_adapter()]),
+            token_part=None,
+            position_part=None,
+        )
+        pipeline_state, token_state, position_state = gpt.init_state()
+        assert pipeline_state == ((),)
+        assert token_state == ()
+        assert position_state == ()
+
+    def test_init_state_learnable_embeddings(self):
+        """Learnable embeddings contribute (network, opt_state) states."""
+        tok_net = DeepNetwork().add_layer(64).add_layer(256)
+        pos_net = DeepNetwork().add_layer(64).add_layer(512)
+        gpt = HybridGPT(
+            tok_table=jnp.ones((256, 64)),
+            pos_table=jnp.ones((512, 64)),
+            pipeline=PCSequential([gelu_adapter()]),
+            token_part=DeepNetworkAdapter(tok_net),
+            position_part=DeepNetworkAdapter(pos_net),
+        )
+        pipeline_state, token_state, position_state = gpt.init_state()
+        assert pipeline_state == ((),)
+        assert token_state[0] is tok_net.state
+        assert position_state[0] is pos_net.state
+
+
+class TestBackwardCompatibility:
+    """Existing construction patterns still work."""
+
+    def test_existing_deep_network_adapter_construction(self):
+        """DeepNetworkAdapter construction works unchanged."""
+        net = DeepNetwork().add_layer(4).add_layer(8)
+        adapter = DeepNetworkAdapter(net, optimizer=optax.adam(1e-3))
+        assert adapter.net is net
+        assert adapter.optimizer is not None
+
+    def test_existing_sequential_construction(self):
+        """PCSequential construction works unchanged."""
+        parts = [gelu_adapter(), gelu_adapter()]
+        assert PCSequential(parts).parts == parts
+
+    def test_existing_residual_construction(self):
+        """Residual construction works unchanged."""
+        branch = gelu_adapter()
+        assert Residual(branch).branch is branch

--- a/tests/test_transplant.py
+++ b/tests/test_transplant.py
@@ -4,6 +4,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
+import optax
 from jax import random
 
 from pyhgf.model import from_embedding, from_feedforward, from_linear
@@ -13,6 +14,14 @@ from pyhgf.model import from_embedding, from_feedforward, from_linear
 # pass to floating-point precision, which validates the layer order, the
 # matrix orientation, and every bias placement independently of any question
 # about learning.
+
+_PARITY = dict(
+    volatility_parent=False,
+    tonic_volatility=-20.0,
+    precision=1e4,
+    expected_precision=1e4,
+)
+_PARITY_LEAF = dict(volatility_parent=False, tonic_volatility=-20.0)
 
 
 def test_from_linear_forward_parity():
@@ -58,3 +67,56 @@ def test_from_embedding_forward_parity():
     np.testing.assert_allclose(
         net.predict(one_hot), jax.vmap(embedding)(ids), rtol=1e-6, atol=1e-7
     )
+
+
+def test_transplanted_feedforward_learns_like_backprop_with_biases():
+    """One batched learning step on a transplanted, *biased* block matches backprop.
+
+    Extends the bias-free parity result to the full feed-forward block with
+    both bias vectors: in the parity configuration, the weight changes on
+    every matrix — bias columns included — must match the batch-averaged
+    gradients of a squared-error loss on the identical forward function, and
+    the per-sample input errors must match the loss gradient at the input.
+    """
+    rng = np.random.default_rng(4)
+    d, h, batch = 6, 12, 5
+    k1, k2 = random.split(random.key(5))
+    fc1 = eqx.nn.Linear(d, h, key=k1)
+    fc2 = eqx.nn.Linear(h, d, key=k2)
+    xb = jnp.asarray(rng.normal(size=(batch, d)))
+    yb = jnp.asarray(rng.normal(size=(batch, d)))
+
+    # Oracle: batch-mean gradients with respect to the folded [W | b] blocks.
+    def forward(w1b, w2b, row):
+        hidden = w1b[:, :-1] @ row + w1b[:, -1]
+        return w2b[:, :-1] @ jax.nn.gelu(hidden) + w2b[:, -1]
+
+    w1b = jnp.concatenate([fc1.weight, fc1.bias[:, None]], axis=1)
+    w2b = jnp.concatenate([fc2.weight, fc2.bias[:, None]], axis=1)
+
+    def mean_loss(w1b_, w2b_):
+        out = jax.vmap(lambda row: forward(w1b_, w2b_, row))(xb)
+        return jnp.mean(jnp.sum(0.5 * (yb - out) ** 2, axis=-1))
+
+    g_w1b, g_w2b = jax.grad(mean_loss, argnums=(0, 1))(w1b, w2b)
+    per_sample_dx = jax.vmap(
+        lambda x_row, y_row: jax.grad(
+            lambda a: jnp.sum(0.5 * (y_row - forward(w1b, w2b, a)) ** 2)
+        )(x_row)
+    )(xb, yb)
+
+    # Transplant, one batch-synchronous step in the parity configuration.
+    net = from_feedforward(fc1, fc2, leaf_kwargs=_PARITY_LEAF, layer_kwargs=_PARITY)
+    lr = 1e-3
+    net.batch_update(xb, yb, optimizer=optax.sgd(lr), update_confidences=False)
+
+    def norm_rel(a, b):
+        return float(jnp.linalg.norm(a - b) / jnp.linalg.norm(b))
+
+    d_w2b = -(net.state.layers[1].weights_in - w2b) / lr  # hidden→output block
+    d_w1b = -(net.state.layers[2].weights_in - w1b) / lr  # input→hidden block
+    assert norm_rel(d_w1b, g_w1b) < 1e-2
+    assert norm_rel(d_w2b, g_w2b) < 1e-2
+    # PyHGF errors are observed-minus-predicted: the negative of the loss
+    # gradient at the input.
+    assert norm_rel(-net.input_errors, per_sample_dx) < 1e-2


### PR DESCRIPTION
## Declarative DeepNetwork API, mixed/fused pipelines, and batch-synchronous learning

Extends the vectorised `DeepNetwork` backend with a declarative construction API and a way to compose PyHGF networks with frozen calculations into larger models (up to a full Transformer), trained locally without backprop or autodiff.

### What's new

- **Declarative construction** (`builder.py`) — `LayerConfig`, `resolve_coupling_fn`, and `DeepNetwork.from_configs` / `from_dict`: build networks from JSON/YAML-serializable configs for reproducible sweeps.
- **Weight transplant** (`transplant.py`) — `from_linear`, `from_feedforward`, `from_embedding`: build a `DeepNetwork` that reproduces a trained Equinox module's forward pass in PyHGF's layer layout.
- **Mixed pipelines** (`hybrid.py`) — `PCModule` with `DeepNetworkAdapter` (learning) / `EquinoxAdapter` (frozen), `PCSequential`, `Residual`, and the `linear_`/`layer_norm_`/`gelu_adapter` helpers. Errors are routed part-by-part with hand-derived backward formulas; no global computation graph.
- **Transformer** (`transformer.py`) — `MultiHeadAttention`, `HybridGPT`, `hybrid_from_gpt`: assemble a GPT from mixed parts, any slot frozen or learning.
- **Fused executor** (`fused.py`) — `FusedPipeline` + `step_report`: run a part tree as a single compiled program per training step, with all state threaded explicitly.
- **New belief-propagation entry points** (`vectorized_belief_propagation.py`, `learning.py`) — batch-synchronous `batch_step` / `sample_step`, split `prediction_sweep` / `update_sweep` / `learn_sweep`, `input_prediction_error`, and rank-one `vectorized_weight_gradient_factors`. Surfaced on `DeepNetwork` as `prediction`, `update`, `input_error`, `batch_update`, `predict_states`.

### Also

- Categorical layers restricted to the output layer (softmax = single N-way choice).
- All new public symbols are documented in `docs/source/api.rst`.
- Tests for builder, hybrid, fused, transplant, batch learning, and the `PCModule` state contract.
