### PR TITLE
Type the two error conventions crossing the hybrid-pipeline boundary

### DIFF
--- a/pyhgf/model/__init__.py
+++ b/pyhgf/model/__init__.py
@@ -15,6 +15,11 @@ from .add_nodes import (
 )
 from .builder import LayerConfig, resolve_coupling_fn
 from .deep_network import DeepNetwork
+from .error_types import (
+    DescentError,
+    ObservedMinusPredicted,
+    validate_error_convention,
+)
 from .fused import FusedPipeline, step_report
 from .hybrid import (
     DeepNetworkAdapter,
@@ -35,6 +40,9 @@ __all__ = [
     "DeepNetwork",
     "LayerConfig",
     "resolve_coupling_fn",
+    "DescentError",
+    "ObservedMinusPredicted",
+    "validate_error_convention",
     "from_linear",
     "from_feedforward",
     "from_embedding",

--- a/pyhgf/model/error_types.py
+++ b/pyhgf/model/error_types.py
@@ -1,0 +1,198 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+"""Type annotations for error conventions in mixed pipelines.
+
+Defines two distinct error types to prevent sign-error bugs:
+
+- **DescentError**: The pipeline convention (gradient-like), used between parts
+  and at the executor boundary. Positive means the output is too high.
+
+- **ObservedMinusPredicted**: PyHGF's internal convention (prediction error),
+  used inside learning parts. Positive means the observation exceeded prediction.
+
+The type system catches when you accidentally mix these conventions, preventing
+silent training divergence caused by a missing negation.
+
+Example:
+    >>> from jax import Array
+    >>> from pyhgf.model.error_types import DescentError, ObservedMinusPredicted
+    >>> import jax.numpy as jnp
+    >>>
+    >>> # Pipeline uses descent errors
+    >>> error_in_pipeline: DescentError = jnp.array([0.1, -0.2])
+    >>>
+    >>> # Converting to PyHGF convention for learning
+    >>> obs_minus_pred: ObservedMinusPredicted = -error_in_pipeline
+    >>>
+    >>> # Type system helps catch mistakes:
+    >>> def wrong_conversion(e: DescentError) -> DescentError:
+    ...     return -e  # Should return ObservedMinusPredicted, not DescentError!
+
+Notes
+-----
+These are :class:`typing.NewType` aliases, so they:
+- Cost nothing at runtime (zero overhead)
+- Help type checkers (mypy, pyright) catch mistakes
+- Document intent and convention in signatures
+- Enable gradual migration: mix old and new code freely
+
+See Also
+--------
+:func:`validate_error_convention` : Test utility to verify backward passes
+"""
+
+from __future__ import annotations
+
+from typing import NewType
+
+DescentError = NewType("DescentError", object)
+"""Error in the pipeline convention (gradient-like).
+
+Used between parts in a mixed pipeline and at the executor boundary.
+Semantics: positive value means the signal at this point was too high
+(i.e., the network's output exceeded the training target).
+
+This is the convention used by standard deep learning frameworks
+(PyTorch, TensorFlow, JAX). It is the **negation** of PyHGF's internal
+prediction-error convention.
+
+Type Alias:
+    ``DescentError = NewType("DescentError", Array)``
+"""
+
+ObservedMinusPredicted = NewType("ObservedMinusPredicted", object)
+"""Error in PyHGF's internal convention (prediction error).
+
+Used inside learning parts (DeepNetworkAdapter) and by PyHGF's core
+belief-update machinery. Semantics: positive value means the observation
+exceeded the model's prediction.
+
+This is the **negation** of the pipeline's descent-error convention.
+
+Type Alias:
+    ``ObservedMinusPredicted = NewType("ObservedMinusPredicted", Array)``
+
+Notes
+-----
+The conversion between conventions is:
+
+    observation = output - descent_error
+    prediction_error = observation - output = -descent_error
+"""
+
+
+def validate_error_convention(
+    part,
+    x: DescentError,
+    y: DescentError,
+    perturb_size: float = 1e-5,
+) -> bool:
+    """Check that a part's backward pass uses the pipeline (descent) convention.
+
+    Runs a finite-difference check: perturbs the input slightly, measures how
+    the output changes, and compares that to what the part claims the input
+    error should be. If they match (to numerical precision), the backward pass
+    uses the descent-error convention correctly.
+
+    This is a **sanity check**, not a proof. It uses finite differences which
+    are noisy, so it's conservative: it prefers false negatives (missing bugs)
+    over false positives (rejecting correct code).
+
+    Parameters
+    ----------
+    part :
+        An EquinoxAdapter (with forward_fn/backward_fn attributes) or a custom PCModule
+        with forward() and backward() methods.
+    x : DescentError
+        Sample input (array-like), shape ``(batch, n_features)`` or ``(n_features,)``.
+        Used to test forward and backward.
+    y : DescentError
+        Sample target (same shape as x). Used to form error for backward pass.
+    perturb_size : float, default 1e-5
+        Magnitude of finite-difference perturbation in input. Smaller is more
+        accurate but noisier; larger is faster but less accurate.
+
+    Returns
+    -------
+    bool
+        True if the backward pass appears to use descent-error convention (to numerical
+        precision). False if it appears to use the opposite convention or something else
+        entirely.
+
+    Raises
+    ------
+    AttributeError
+        If part lacks required init_state and either (forward/backward methods
+        or forward_fn/backward_fn attributes).
+
+    Notes
+    -----
+    This function is intended for testing custom part implementations. For
+    production use, check the part type and trust the implementation.
+
+    Example
+    -------
+    >>> from pyhgf.model import gelu_adapter
+    >>> from pyhgf.model.error_types import validate_error_convention
+    >>> import jax.numpy as jnp
+    >>>
+    >>> part = gelu_adapter()
+    >>> x = jnp.array([1.0, -0.5, 2.0])
+    >>> y = jnp.array([0.5, 0.1, 1.5])
+    >>> is_correct = validate_error_convention(part, x, y)
+    >>> print(f"Backward convention correct: {is_correct}")
+    Backward convention correct: True
+    """
+    import jax
+    import jax.numpy as jnp
+
+    # Initialize state
+    state = part.init_state()
+
+    # Handle both method-based (PCSequential, etc.) and attribute-based (EquinoxAdapter) parts
+    if hasattr(part, "forward_fn"):
+        # EquinoxAdapter: forward_fn(x) -> (output, cache)
+        output, cache = part.forward_fn(x)
+    else:
+        # Custom PCModule: forward(state, x) -> (output, cache)
+        output, cache = part.forward(state, x)
+
+    # Error at output (descent convention)
+    error = output - y
+
+    # Finite-difference estimate of input sensitivity
+    # For a small perturbation eps in input, the output changes by ~eps * jacobian
+    # So input_error ~ error @ jacobian^T ~ error * (d output / d input)
+    eps_x = jnp.zeros_like(x)
+    if jnp.ndim(x) == 1:
+        eps_x = eps_x.at[0].set(perturb_size)
+    else:
+        eps_x = eps_x.at[0, 0].set(perturb_size)
+
+    if hasattr(part, "forward_fn"):
+        output_plus, _ = part.forward_fn(x + eps_x)
+    else:
+        output_plus, _ = part.forward(state, x + eps_x)
+
+    fd_slope = (output_plus - output) / perturb_size
+
+    # Expected input error: error flows back through the slope
+    expected_input_error = error * fd_slope
+
+    # Part's claimed input error
+    if hasattr(part, "backward_fn"):
+        # EquinoxAdapter: backward_fn(cache, error) -> error_in
+        actual_input_error = part.backward_fn(cache, error)
+    else:
+        # Custom PCModule: backward(state, cache, error) -> (error_in, ...)
+        actual_input_error, _, _ = part.backward(state, cache, error)
+
+    # Compare: loose tolerance (this is noisy)
+    # We compare element-wise and check if most elements agree
+    relative_error = jnp.abs(
+        (actual_input_error - expected_input_error)
+        / (jnp.abs(expected_input_error) + 1e-8)
+    )
+    fraction_correct = jnp.mean(relative_error < 0.3)  # 30% tolerance
+
+    return bool(fraction_correct >= 0.8)  # At least 80% of elements agree

--- a/pyhgf/model/error_types.py
+++ b/pyhgf/model/error_types.py
@@ -85,18 +85,21 @@ def validate_error_convention(
     part,
     x: DescentError,
     y: DescentError,
-    perturb_size: float = 1e-5,
+    rtol: float = 1e-4,
+    atol: float = 1e-5,
 ) -> bool:
     """Check that a part's backward pass uses the pipeline (descent) convention.
 
-    Runs a finite-difference check: perturbs the input slightly, measures how
-    the output changes, and compares that to what the part claims the input
-    error should be. If they match (to numerical precision), the backward pass
-    uses the descent-error convention correctly.
+    A descent-convention backward pass must map the error at the output onto the
+    error at the input by the vector-Jacobian product ``Jᵀ @ error``, where
+    ``J = ∂output/∂input``. This is exactly what reverse-mode autodiff computes,
+    so the check compares the part's hand-derived ``backward`` against the VJP
+    that :func:`jax.vjp` produces for its ``forward``.
 
-    This is a **sanity check**, not a proof. It uses finite differences which
-    are noisy, so it's conservative: it prefers false negatives (missing bugs)
-    over false positives (rejecting correct code).
+    The comparison is exact (up to floating-point tolerance) and works for any
+    input shape, so it catches a flipped sign or a wrong Jacobian anywhere in the
+    array. If the backward instead used PyHGF's observed-minus-predicted
+    convention, every element would be negated and the check would fail.
 
     Parameters
     ----------
@@ -108,16 +111,16 @@ def validate_error_convention(
         Used to test forward and backward.
     y : DescentError
         Sample target (same shape as x). Used to form error for backward pass.
-    perturb_size : float, default 1e-5
-        Magnitude of finite-difference perturbation in input. Smaller is more
-        accurate but noisier; larger is faster but less accurate.
+    rtol : float, default 1e-4
+        Relative tolerance for the element-wise comparison against the autodiff VJP.
+    atol : float, default 1e-5
+        Absolute tolerance for the element-wise comparison against the autodiff VJP.
 
     Returns
     -------
     bool
-        True if the backward pass appears to use descent-error convention (to numerical
-        precision). False if it appears to use the opposite convention or something else
-        entirely.
+        True if the backward pass matches the autodiff VJP (descent-error
+        convention). False if it uses the opposite convention or a wrong Jacobian.
 
     Raises
     ------
@@ -128,7 +131,8 @@ def validate_error_convention(
     Notes
     -----
     This function is intended for testing custom part implementations. For
-    production use, check the part type and trust the implementation.
+    production use, check the part type and trust the implementation. The
+    ``forward`` pass must be differentiable by JAX for the VJP to be available.
 
     Example
     -------
@@ -149,37 +153,27 @@ def validate_error_convention(
     # Initialize state
     state = part.init_state()
 
-    # Handle both method-based (PCSequential, etc.) and attribute-based (EquinoxAdapter) parts
+    # Handle both attribute-based (EquinoxAdapter, forward_fn/backward_fn) and
+    # method-based (custom PCModule, forward/backward) parts. In both cases
+    # ``forward`` returns only the output, so it can be differentiated on its own.
     if hasattr(part, "forward_fn"):
-        # EquinoxAdapter: forward_fn(x) -> (output, cache)
-        output, cache = part.forward_fn(x)
+        forward = lambda inp: part.forward_fn(inp)[0]  # noqa: E731
+        _, cache = part.forward_fn(x)
     else:
-        # Custom PCModule: forward(state, x) -> (output, cache)
-        output, cache = part.forward(state, x)
+        forward = lambda inp: part.forward(state, inp)[0]  # noqa: E731
+        _, cache = part.forward(state, x)
 
-    # Error at output (descent convention)
+    # Output and the reverse-mode VJP of the forward pass.
+    output, vjp_fn = jax.vjp(forward, x)
+
+    # Error at the output in the descent convention (positive = output too high).
     error = output - y
 
-    # Finite-difference estimate of input sensitivity
-    # For a small perturbation eps in input, the output changes by ~eps * jacobian
-    # So input_error ~ error @ jacobian^T ~ error * (d output / d input)
-    eps_x = jnp.zeros_like(x)
-    if jnp.ndim(x) == 1:
-        eps_x = eps_x.at[0].set(perturb_size)
-    else:
-        eps_x = eps_x.at[0, 0].set(perturb_size)
+    # Autodiff ground truth: the input error a descent-convention backward pass
+    # must produce is the vector-Jacobian product Jᵀ @ error.
+    (expected_input_error,) = vjp_fn(error)
 
-    if hasattr(part, "forward_fn"):
-        output_plus, _ = part.forward_fn(x + eps_x)
-    else:
-        output_plus, _ = part.forward(state, x + eps_x)
-
-    fd_slope = (output_plus - output) / perturb_size
-
-    # Expected input error: error flows back through the slope
-    expected_input_error = error * fd_slope
-
-    # Part's claimed input error
+    # The part's hand-derived input error.
     if hasattr(part, "backward_fn"):
         # EquinoxAdapter: backward_fn(cache, error) -> error_in
         actual_input_error = part.backward_fn(cache, error)
@@ -187,12 +181,6 @@ def validate_error_convention(
         # Custom PCModule: backward(state, cache, error) -> (error_in, ...)
         actual_input_error, _, _ = part.backward(state, cache, error)
 
-    # Compare: loose tolerance (this is noisy)
-    # We compare element-wise and check if most elements agree
-    relative_error = jnp.abs(
-        (actual_input_error - expected_input_error)
-        / (jnp.abs(expected_input_error) + 1e-8)
+    return bool(
+        jnp.allclose(actual_input_error, expected_input_error, rtol=rtol, atol=atol)
     )
-    fraction_correct = jnp.mean(relative_error < 0.3)  # 30% tolerance
-
-    return bool(fraction_correct >= 0.8)  # At least 80% of elements agree

--- a/pyhgf/model/hybrid.py
+++ b/pyhgf/model/hybrid.py
@@ -39,6 +39,7 @@ import jax.numpy as jnp
 import optax
 
 from pyhgf.model.deep_network import DeepNetwork
+from pyhgf.model.error_types import DescentError, ObservedMinusPredicted
 
 __all__ = [
     "PCModule",
@@ -141,6 +142,19 @@ class EquinoxAdapter(PCModule):
     - ``backward_fn(cache, error) -> error_in`` translates the error at the
       output into the error at the input, using only the cache.
 
+    Error Convention
+    ----------------
+    Both forward_fn and backward_fn use the **descent-error convention**
+    (see :mod:`pyhgf.model.error_types`):
+
+    - forward_fn receives arrays in the pipeline's usual format
+    - backward_fn receives :class:`~pyhgf.model.error_types.DescentError`
+      (positive = signal too high) and returns the same convention
+
+    The hand-derived backward formula must respect this convention:
+    if the function is ``y = f(x)`` and loss is ``L(y)``, then
+    ``backward_fn`` should return ``∂L/∂x = (∂L/∂y) @ (∂y/∂x)^T``.
+
     Use the ready-made constructors :func:`gelu_adapter` and
     :func:`layer_norm_adapter` for the standard Transformer pieces.
     """
@@ -148,7 +162,7 @@ class EquinoxAdapter(PCModule):
     def __init__(
         self,
         forward_fn: Callable[[jnp.ndarray], tuple[jnp.ndarray, tuple]],
-        backward_fn: Callable[[tuple, jnp.ndarray], jnp.ndarray],
+        backward_fn: Callable[[tuple, DescentError], DescentError],
     ):
         self.forward_fn = forward_fn
         self.backward_fn = backward_fn
@@ -248,13 +262,28 @@ class DeepNetworkAdapter(PCModule):
     computation as :meth:`~pyhgf.model.DeepNetwork.batch_update`, staged
     in-trace) and threads the error at the network's input onward.
 
-    The learning part's boundary is where the descent-error convention of the
-    pipeline meets PyHGF's observed-minus-predicted convention:
+    Error Convention Bridge
+    -----------------------
+    This part is where the pipeline's **descent-error convention** meets
+    **PyHGF's observed-minus-predicted convention** (see :mod:`pyhgf.model.error_types`).
+    The executor performs the conversion at this single boundary:
 
-    - the error *enters* by clamping ``output - error`` as the observation
-      the network should have produced (so the leaf prediction error is
-      exactly ``-error``);
-    - the error *leaves* as the negated input-layer prediction error.
+    **Forward (pipeline → PyHGF):**
+        Input (DescentError) is unchanged; used as usual.
+
+    **Backward (PyHGF → pipeline):**
+        1. Pipeline passes :class:`~pyhgf.model.error_types.DescentError` (positive = too high)
+        2. This part converts to :class:`~pyhgf.model.error_types.ObservedMinusPredicted`:
+           ``observation = output - descent_error``
+        3. PyHGF's ``batch_update`` treats this as the target, computing
+           ``prediction_error = observation - output = -descent_error``
+        4. Learning uses the prediction error natively
+        5. Input error (also prediction-error convention) is negated back to
+           descent-error convention before passing to the previous part
+
+    This two-step conversion (descent↔observed-minus-predicted) happens
+    **in exactly one place**: inside the executor's backward pass for this
+    adapter. No other part needs to know about the convention flip.
 
     Parameters
     ----------

--- a/tests/test_error_types.py
+++ b/tests/test_error_types.py
@@ -1,0 +1,199 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+"""Tests for error convention type annotations and validation.
+
+Validates that:
+1. Error type markers are defined and importable
+2. validate_error_convention detects correct implementations
+3. The validation catches sign errors (or at least detects unusual patterns)
+4. Type annotations document the convention correctly
+"""
+
+from __future__ import annotations
+
+import jax.nn
+import jax.numpy as jnp
+import pytest
+
+from pyhgf.model import (
+    DescentError,
+    ObservedMinusPredicted,
+    gelu_adapter,
+    validate_error_convention,
+)
+from pyhgf.model.error_types import validate_error_convention as direct_validate
+
+
+class TestErrorTypeMarkers:
+    """Test that error type markers exist and are properly defined."""
+
+    def test_descent_error_exists(self):
+        """DescentError is defined and importable."""
+        assert DescentError is not None
+
+    def test_observed_minus_predicted_exists(self):
+        """ObservedMinusPredicted is defined and importable."""
+        assert ObservedMinusPredicted is not None
+
+    def test_error_types_are_distinct(self):
+        """Error types are distinct (different NewType instances)."""
+        # NewTypes are callable, and calling them returns the value unchanged
+        x = jnp.array([1.0, 2.0])
+        descent = DescentError(x)
+        obs_minus_pred = ObservedMinusPredicted(x)
+
+        # Both are the same array at runtime, but types are different
+        assert jnp.array_equal(descent, obs_minus_pred)
+        # Type names are distinct
+        assert DescentError.__name__ == "DescentError"
+        assert ObservedMinusPredicted.__name__ == "ObservedMinusPredicted"
+
+
+class TestValidateErrorConvention:
+    """Test error convention validation utility."""
+
+    def test_validate_gelu_adapter_correct(self):
+        """GELU adapter's backward formula uses descent-error convention."""
+        part = gelu_adapter()
+
+        # Simple test case
+        x = DescentError(jnp.array([0.5, -0.2, 1.5]))
+        y = DescentError(jnp.array([0.3, -0.1, 1.0]))
+
+        # validate_error_convention works with parts that have init_state/forward/backward
+        # For adapters, we need to call through forward_fn/backward_fn
+        result = validate_error_convention(part, x, y)
+        # GELU is a standard activation with a known derivative, so
+        # the validation should recognize it
+        assert isinstance(result, (bool, jnp.ndarray))
+
+    def test_validate_returns_bool(self):
+        """Validation function returns a boolean."""
+        part = gelu_adapter()
+
+        x = DescentError(jnp.array([1.0, -2.0, 3.0]))
+        y = DescentError(jnp.array([0.5, -1.0, 1.5]))
+
+        # validate_error_convention works with any part that has the protocol
+        result = validate_error_convention(part, x, y)
+        assert isinstance(result, (bool, jnp.ndarray))
+
+    def test_validate_missing_method_raises(self):
+        """Validation raises AttributeError if part is incomplete."""
+        from pyhgf.model.error_types import validate_error_convention as val_fn
+
+        # Object with no init_state method
+        class IncompleteAdapter:
+            def forward(self, state, x):
+                return x, ()
+
+            def backward(self, state, cache, error):
+                return error, state, ()
+
+        adapter = IncompleteAdapter()
+        x = DescentError(jnp.array([1.0]))
+        y = DescentError(jnp.array([0.5]))
+
+        with pytest.raises(AttributeError):
+            val_fn(adapter, x, y)
+
+
+class TestErrorConventionDocumentation:
+    """Test that error conventions are properly documented."""
+
+    def test_equinox_adapter_has_error_convention_docs(self):
+        """EquinoxAdapter docstring mentions error convention."""
+        from pyhgf.model import EquinoxAdapter
+
+        doc = EquinoxAdapter.__doc__
+        assert "Error Convention" in doc or "descent" in doc.lower()
+
+    def test_deep_network_adapter_has_boundary_docs(self):
+        """DeepNetworkAdapter docstring explains the convention boundary."""
+        from pyhgf.model import DeepNetworkAdapter
+
+        doc = DeepNetworkAdapter.__doc__
+        assert "Error Convention" in doc or "boundary" in doc.lower()
+
+    def test_error_types_module_has_explanation(self):
+        """error_types module docstring explains both conventions."""
+        from pyhgf.model import error_types
+
+        doc = error_types.__doc__
+        assert "DescentError" in doc
+        assert "ObservedMinusPredicted" in doc
+
+
+class TestConventionSemanticsDocumentation:
+    """Test that the semantics are clearly documented in the module."""
+
+    def test_error_types_module_docstring(self):
+        """error_types module has comprehensive semantics documentation."""
+        from pyhgf.model import error_types
+
+        doc = error_types.__doc__
+        assert "DescentError" in doc
+        assert "descent" in doc.lower()
+        assert "convention" in doc.lower()
+
+
+class TestTypeConversionConcept:
+    """Test that type conversion between conventions is conceptually clear."""
+
+    def test_descent_to_obs_minus_pred_formula_documented(self):
+        """The conversion formula is documented."""
+        from pyhgf.model.error_types import ObservedMinusPredicted as OMP
+
+        doc = OMP.__doc__
+        # Should mention the conversion: -descent = obs - pred
+        assert "negation" in doc.lower() or "-" in doc
+
+    def test_conversion_is_negation(self):
+        """Converting between conventions is just negation."""
+        # This is conceptual; at runtime NewTypes are transparent
+        from pyhgf.model.error_types import DescentError as DE
+        from pyhgf.model.error_types import ObservedMinusPredicted as OMP
+
+        x = jnp.array([1.0, -2.0])
+
+        # Conceptually: descent_error = x, then obs_minus_pred = -x
+        # At runtime they're the same type, but types document intent
+        descent = DE(x)
+        obs_minus = OMP(-x)
+
+        # They're negations of each other
+        assert jnp.allclose(descent, -obs_minus)
+
+
+class TestBackwardCompatibility:
+    """Test that existing code without type hints still works."""
+
+    def test_gelu_adapter_still_works_untyped(self):
+        """GELU adapter works regardless of type annotation."""
+        part = gelu_adapter()
+
+        # No type annotation
+        x = jnp.array([1.0, -0.5])
+        y = jnp.array([0.5, -0.2])
+
+        state = part.init_state()
+        output, cache = part.forward_fn(x)
+        error = output - y
+        error_in = part.backward_fn(cache, error)
+
+        # Should just work
+        assert error_in.shape == x.shape
+
+    def test_sequential_composition_untyped(self):
+        """Sequential parts work regardless of type annotation."""
+        from pyhgf.model import PCSequential
+
+        part1 = gelu_adapter()
+        part2 = gelu_adapter()
+        seq = PCSequential([part1, part2])
+
+        x = jnp.array([1.0, -0.5])
+        state = seq.init_state()
+
+        # Should work without explicit types
+        assert state is not None

--- a/tests/test_error_types.py
+++ b/tests/test_error_types.py
@@ -19,9 +19,44 @@ from pyhgf.model import (
     DescentError,
     ObservedMinusPredicted,
     gelu_adapter,
+    layer_norm_adapter,
     validate_error_convention,
 )
 from pyhgf.model.error_types import validate_error_convention as direct_validate
+
+
+class _IdentityModule:
+    """Minimal method-based part (forward/backward) using the descent convention.
+
+    Exercises the ``part.forward(state, x)`` / ``part.backward(state, cache, error)``
+    branches of :func:`validate_error_convention`, i.e. the path for custom
+    :class:`~pyhgf.model.hybrid.PCModule` implementations rather than the attribute-
+    based :class:`~pyhgf.model.hybrid.EquinoxAdapter`.
+
+    The forward pass is the identity (slope 1), so the descent-convention backward pass
+    returns the output error unchanged.
+    """
+
+    def init_state(self):
+        return ()
+
+    def forward(self, state, x):
+        return x, ()
+
+    def backward(self, state, cache, error):
+        return error, state, ()
+
+
+class _SignFlippedModule(_IdentityModule):
+    """Same as :class:`_IdentityModule` but the backward pass negates the error.
+
+    This is the classic convention bug: returning an observed-minus-predicted
+    error where a descent error is expected. :func:`validate_error_convention`
+    should reject it.
+    """
+
+    def backward(self, state, cache, error):
+        return -error, state, ()
 
 
 class TestErrorTypeMarkers:
@@ -60,23 +95,65 @@ class TestValidateErrorConvention:
         x = DescentError(jnp.array([0.5, -0.2, 1.5]))
         y = DescentError(jnp.array([0.3, -0.1, 1.0]))
 
-        # validate_error_convention works with parts that have init_state/forward/backward
-        # For adapters, we need to call through forward_fn/backward_fn
-        result = validate_error_convention(part, x, y)
-        # GELU is a standard activation with a known derivative, so
-        # the validation should recognize it
-        assert isinstance(result, (bool, jnp.ndarray))
+        # GELU's hand-derived backward matches the autodiff VJP of its forward.
+        assert validate_error_convention(part, x, y) is True
 
     def test_validate_returns_bool(self):
-        """Validation function returns a boolean."""
+        """Validation function returns a plain Python bool."""
         part = gelu_adapter()
 
         x = DescentError(jnp.array([1.0, -2.0, 3.0]))
         y = DescentError(jnp.array([0.5, -1.0, 1.5]))
 
-        # validate_error_convention works with any part that has the protocol
         result = validate_error_convention(part, x, y)
-        assert isinstance(result, (bool, jnp.ndarray))
+        assert isinstance(result, bool)
+
+    def test_validate_method_based_part_correct(self):
+        """Method-based parts (forward/backward) validate under descent convention."""
+        part = _IdentityModule()
+
+        x = DescentError(jnp.array([1.0, -0.5, 2.0]))
+        y = DescentError(jnp.array([0.5, 0.1, 1.5]))
+
+        assert validate_error_convention(part, x, y) is True
+
+    def test_validate_batched_input(self):
+        """Validation handles multi-dimensional (batched) input."""
+        part = _IdentityModule()
+
+        x = DescentError(jnp.array([[1.0, -0.5, 2.0], [0.2, 1.3, -1.0]]))
+        y = DescentError(jnp.array([[0.5, 0.1, 1.5], [0.0, 1.0, -0.5]]))
+
+        assert validate_error_convention(part, x, y) is True
+
+    def test_validate_detects_sign_error(self):
+        """A backward pass with the wrong (negated) sign fails validation.
+
+        The error is caught even though only the sign is wrong and every other aspect of
+        the backward pass is correct.
+        """
+        part = _SignFlippedModule()
+
+        x = DescentError(jnp.array([1.0, -0.5, 2.0]))
+        y = DescentError(jnp.array([0.5, 0.1, 1.5]))
+
+        assert validate_error_convention(part, x, y) is False
+
+    def test_validate_layer_norm_non_diagonal_jacobian(self):
+        """LayerNorm validates even though its Jacobian is not diagonal.
+
+        LayerNorm couples every output to every input, so the backward pass is a full
+        vector-Jacobian product rather than an element-wise scaling. The autodiff
+        comparison handles this exactly.
+        """
+        import equinox as eqx
+
+        part = layer_norm_adapter(eqx.nn.LayerNorm(shape=(4,)))
+
+        x = DescentError(jnp.array([1.0, -0.5, 2.0, 0.3]))
+        y = DescentError(jnp.array([0.5, 0.1, 1.5, 0.0]))
+
+        assert validate_error_convention(part, x, y) is True
 
     def test_validate_missing_method_raises(self):
         """Validation raises AttributeError if part is incomplete."""


### PR DESCRIPTION
In pyhgf's "hybrid" / mixed pipelines, you can chain together two kinds of building blocks:
- Standard deep-learning parts (like a GELU activation or layer-norm) that pass errors around the way PyTorch/TensorFlow/JAX do, the "gradient" convention, where a positive error means "the output was too high."
- PyHGF learning parts that use the framework's native belief-updating math, the "prediction error" convention, where a positive error means "the observation was higher than the prediction."
These two conventions are exact negatives of each other. If you accidentally mix them up the code runs fine, but training silently diverges. That's a nasty class of bug: invisible, and only detectable by noticing the model won't learn.

This PR makes this sign convention explicit and self-documenting so those bugs are caught or avoided, without changing any runtime behavior:

`DescentError` (gradient-like: positive = output too high) and `ObservedMinusPredicted` (PyHGF's prediction error: positive = observation exceeded prediction) are now distinct annotated types, with `validate_error_convention` as a runtime sanity check. The hybrid-pipeline docstrings spell out where the single descent ↔ observed-minus-predicted conversion happens (the executor's backward pass for `DeepNetworkAdapter`), and `EquinoxAdapter.backward_fn`'s signature declares the convention it must respect. A missing negation at this boundary trains silently in the wrong direction; the types make that mistake visible.