### PR TITLE
Add batch-synchronous learning to the Rust backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +142,12 @@ dependencies = [
  "redox_users",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "errno"
@@ -288,6 +313,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+ "rayon",
 ]
 
 [[package]]
@@ -546,6 +572,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +626,7 @@ dependencies = [
  "pyo3",
  "rand",
  "rand_distr",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ pyo3 = { version = "0.28.1", features = ["extension-module", "abi3-py37"] }
 numpy = "0.28"
 rand = { version = "0.9", features = ["small_rng"] }
 rand_distr = "0.5"
-ndarray = { version = "0.16", features = ["matrixmultiply-threading"] }
+ndarray = { version = "0.16", features = ["matrixmultiply-threading", "rayon"] }
+rayon = "1.10"
 
 # BLAS provider, linked only under the `blas` feature, with a per-platform
 # backend: the system Accelerate framework on Apple targets (no build step),

--- a/src/model/deep_network.rs
+++ b/src/model/deep_network.rs
@@ -146,6 +146,28 @@ fn extract_for_fit(x: &Bound<'_, PyAny>, expected_cols: usize, name: &str) -> Py
     Ok(mat)
 }
 
+/// Parse an optimizer name (`"adam"` or `"sgd"`) into an [`Optimizer`].
+fn parse_optimizer(name: &str, learning_rate: f64) -> PyResult<Optimizer> {
+    match name.to_lowercase().as_str() {
+        "adam" => Ok(Optimizer::adam(learning_rate)),
+        "sgd" => Ok(Optimizer::sgd(learning_rate)),
+        other => Err(PyValueError::new_err(format!(
+            "Unknown optimizer '{other}'. Use 'adam' or 'sgd'."
+        ))),
+    }
+}
+
+/// Parse a `learning_kind` name into a [`WeightKind`].
+fn parse_weight_kind(kind: &str) -> PyResult<WeightKind> {
+    match kind {
+        "precision_weighted" => Ok(WeightKind::PrecisionWeighted),
+        "standard" => Ok(WeightKind::Standard),
+        other => Err(PyValueError::new_err(format!(
+            "Unknown learning_kind '{other}'. Use 'precision_weighted' or 'standard'."
+        ))),
+    }
+}
+
 #[pymethods]
 impl DeepNetwork {
     #[new]
@@ -316,24 +338,8 @@ impl DeepNetwork {
         weight_update: bool,
         time_step: f64,
     ) -> PyResult<Py<PyAny>> {
-        let opt = match optimizer.to_lowercase().as_str() {
-            "adam" => Optimizer::adam(learning_rate),
-            "sgd" => Optimizer::sgd(learning_rate),
-            other => {
-                return Err(PyValueError::new_err(format!(
-                    "Unknown optimizer '{other}'. Use 'adam' or 'sgd'."
-                )))
-            }
-        };
-        let kind = match learning_kind {
-            "precision_weighted" => WeightKind::PrecisionWeighted,
-            "standard" => WeightKind::Standard,
-            other => {
-                return Err(PyValueError::new_err(format!(
-                    "Unknown learning_kind '{other}'. Use 'precision_weighted' or 'standard'."
-                )))
-            }
-        };
+        let opt = parse_optimizer(optimizer, learning_rate)?;
+        let kind = parse_weight_kind(learning_kind)?;
 
         slf.require_net()?;
         let xmat = extract_for_fit(&x, slf.top_size(), "x")?;
@@ -379,6 +385,108 @@ impl DeepNetwork {
             }
         });
         Ok(out.to_pyarray(py).into_any().unbind())
+    }
+
+    /// One batch-synchronous learning step over many samples at once,
+    /// mirroring the JAX `DeepNetwork.batch_update`. Every sample in the
+    /// batch is processed from the same state (same weights, same
+    /// confidences); the per-sample weight gradients and confidence changes
+    /// are then averaged and applied once, so the whole batch counts as a
+    /// single observation. This differs from `fit`, which scans samples
+    /// sequentially and lets the confidences adapt from one sample to the
+    /// next. `optimizer=None` (default) freezes the weights; pass `"adam"` or
+    /// `"sgd"` with `learning_rate` to learn. `update_confidences=False`
+    /// keeps the carried precisions pinned, the setting used for exact
+    /// comparisons against backpropagation. Returns the per-sample prediction
+    /// errors at the input (top) layer, shape `(n_samples, n_input_features)`;
+    /// they follow the observed minus predicted convention, the negative of a
+    /// squared-error loss gradient with respect to the predictors.
+    #[pyo3(signature = (
+        x, y,
+        optimizer = None,
+        learning_rate = 1e-3,
+        learning_kind = "precision_weighted",
+        update_confidences = true,
+        time_step = 1.0,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn batch_update<'py>(
+        mut slf: PyRefMut<'py, Self>,
+        py: Python<'py>,
+        x: Bound<'py, PyAny>,
+        y: Bound<'py, PyAny>,
+        optimizer: Option<&str>,
+        learning_rate: f64,
+        learning_kind: &str,
+        update_confidences: bool,
+        time_step: f64,
+    ) -> PyResult<Py<PyAny>> {
+        let opt = optimizer
+            .map(|name| parse_optimizer(name, learning_rate))
+            .transpose()?;
+        let kind = parse_weight_kind(learning_kind)?;
+
+        slf.require_net()?;
+        if slf.configs.len() < 2 {
+            return Err(PyValueError::new_err(
+                "The network has a single layer: there is no layer below the \
+                 input layer to route an error from.",
+            ));
+        }
+        let (xmat, x_was_1d) = extract_matrix(&x)?;
+        let (ymat, y_was_1d) = extract_matrix(&y)?;
+        if x_was_1d || y_was_1d {
+            return Err(PyValueError::new_err(
+                "batch_update() operates on batches: x and y must be 2D \
+                 (batch, n_features).",
+            ));
+        }
+        check_predict_cols(xmat.ncols(), slf.top_size())?;
+        if ymat.ncols() != slf.bottom_size() {
+            return Err(PyValueError::new_err(format!(
+                "y has {} feature column(s) but the output (bottom) layer has {} node(s).",
+                ymat.ncols(),
+                slf.bottom_size()
+            )));
+        }
+        if xmat.nrows() != ymat.nrows() {
+            return Err(PyValueError::new_err(format!(
+                "x and y must have the same number of samples, got {} and {}.",
+                xmat.nrows(),
+                ymat.nrows()
+            )));
+        }
+
+        let this = &mut *slf;
+        if let Some(opt) = opt {
+            // Same reset-on-change semantics as `fit`.
+            if this.last_optimizer != Some(opt) {
+                this.opt_state = None;
+                this.last_optimizer = Some(opt);
+            }
+            if this.opt_state.is_none() {
+                this.opt_state = Some(OptState::init(this.net.as_ref().unwrap()));
+            }
+        }
+        let net = this.net.as_mut().unwrap();
+        // A stale opt_state from an earlier call is inert without an
+        // optimizer: the engine only steps the weights when both are given.
+        let opt_state = this.opt_state.as_mut();
+
+        // Release the GIL for the batched step, as in `fit`: it touches only
+        // owned Rust data, and the chunk workers never call into Python.
+        let errors = py.detach(|| {
+            net.batch_update(
+                xmat.view(),
+                ymat.view(),
+                opt.as_ref(),
+                opt_state,
+                time_step,
+                kind,
+                update_confidences,
+            )
+        });
+        Ok(errors.to_pyarray(py).into_any().unbind())
     }
 
     /// Initialise all inter-layer weights with a named strategy — `"xavier"`,

--- a/src/updates/vectorised/volatile/prediction_error.rs
+++ b/src/updates/vectorised/volatile/prediction_error.rs
@@ -32,10 +32,7 @@ pub fn layer_prediction_error(
         .and(&layer.precision)
         .and(&layer.mean)
         .and(&layer.expected_mean)
-        .map_collect(|&ep, &p, &m, &em| {
-            let d = m - em;
-            ep / p + ep * (d * d) - 1.0
-        });
+        .map_collect(|&ep, &p, &m, &em| volatility_pe_node(ep, p, m, em));
     layer.volatility_prediction_error = Some(vol_pe);
 
     match volatility_updates {
@@ -51,6 +48,36 @@ pub fn layer_prediction_error(
     }
 }
 
+/// The value-level volatility prediction error of one node:
+/// `Δ = π̃/π + π̃·δ² − 1`.
+#[inline]
+pub(crate) fn volatility_pe_node(ep: f64, p: f64, m: f64, em: f64) -> f64 {
+    let d = m - em;
+    ep / p + ep * (d * d) - 1.0
+}
+
+/// Standard volatility-level posterior of one node: precision first
+/// (`clip(π̂_vol + 0.5·(κγ)² + (κγ)²·Δ − 0.5·κ²·γ·Δ)`), then the mean from the
+/// just-updated precision (`μ_vol = μ̂_vol + κγΔ / (2·π_vol)`). Returns
+/// `(precision_vol, mean_vol)`. The single source shared by the per-sample
+/// and the batched kernels, so the two paths cannot drift.
+#[inline]
+pub(crate) fn standard_vol_node(
+    k: f64,
+    g: f64,
+    dpe: f64,
+    ep: f64,
+    em: f64,
+    max_posterior_precision: f64,
+) -> (f64, f64) {
+    let ke = k * g;
+    let ke2 = ke * ke;
+    let contrib = 0.5 * ke2 + ke2 * dpe - 0.5 * (k * k) * g * dpe;
+    let pp = (ep + contrib).min(max_posterior_precision);
+    let m = em + (k * g * dpe) / (pp * 2.0);
+    (pp, m)
+}
+
 /// Standard volatility-level posterior: precision first, then mean.
 fn volatility_posterior_standard(
     state: &mut LayerState,
@@ -63,28 +90,69 @@ fn volatility_posterior_standard(
     let epv = state.expected_precision_vol.as_ref().unwrap();
     let emv = state.expected_mean_vol.as_ref().unwrap();
 
-    // Precision first: clip(π̂_vol + 0.5·(κγ)² + (κγ)²·Δ − 0.5·κ²·γ·Δ).
-    let posterior_precision_vol = ndarray::Zip::from(kappa)
-        .and(eff)
-        .and(vpe)
-        .and(epv)
-        .map_collect(|&k, &g, &dpe, &ep| {
-            let ke = k * g;
-            let ke2 = ke * ke;
-            let contrib = 0.5 * ke2 + ke2 * dpe - 0.5 * (k * k) * g * dpe;
-            (ep + contrib).min(max_posterior_precision)
-        });
-
-    // Mean using the just-updated precision: μ_vol = μ̂_vol + κγΔ / (2·π_vol).
-    let posterior_mean_vol = ndarray::Zip::from(emv)
-        .and(kappa)
-        .and(eff)
-        .and(vpe)
-        .and(&posterior_precision_vol)
-        .map_collect(|&m, &k, &g, &dpe, &pp| m + (k * g * dpe) / (pp * 2.0));
+    let n = kappa.len();
+    let mut posterior_precision_vol = Array1::<f64>::zeros(n);
+    let mut posterior_mean_vol = Array1::<f64>::zeros(n);
+    for i in 0..n {
+        let (pp, m) = standard_vol_node(
+            kappa[i],
+            eff[i],
+            vpe[i],
+            epv[i],
+            emv[i],
+            max_posterior_precision,
+        );
+        posterior_precision_vol[i] = pp;
+        posterior_mean_vol[i] = m;
+    }
 
     state.precision_vol = Some(posterior_precision_vol);
     state.mean_vol = Some(posterior_mean_vol);
+}
+
+/// eHGF volatility-level posterior of one node: mean first (using the
+/// expected precision as the approximation), then the "safe" precision
+/// increment recomputed from the updated mean and floored at zero. Returns
+/// `(precision_vol, mean_vol)`.
+///
+/// Plain exponentials: the JAX eHGF posterior applies no underflow guard here
+/// (unlike the prediction kernels' `guarded_volatility`); the only floor is
+/// the `1e-128` clamp on `previous_variance`. The per-node backend's eHGF
+/// update follows the same convention.
+#[inline]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn ehgf_vol_node(
+    k: f64,
+    t: f64,
+    em: f64,
+    ep: f64,
+    g: f64,
+    dpe: f64,
+    cond: f64,
+    prec: f64,
+    mean: f64,
+    emean: f64,
+    time_step: f64,
+    max_posterior_precision: f64,
+) -> (f64, f64) {
+    // Mean first, using expected_precision_vol as the approximation.
+    let posterior_mean_vol = em + (k * g * dpe) / (ep * 2.0);
+
+    let pvol = |exponent: f64| time_step * exponent.exp();
+    // Reconstruct the value level's pre-prediction variance exactly.
+    let mgf = (k * k) / (ep * 2.0);
+    let predicted_vol = pvol(t + k * em + mgf);
+    let previous_variance = (1.0 / cond - predicted_vol).max(1e-128);
+    // Re-predict volatility / precision from the posterior mean.
+    let repredicted_vol = pvol(k * posterior_mean_vol + t);
+    let expected_precision = 1.0 / (previous_variance + repredicted_vol);
+    let eff2 = repredicted_vol * expected_precision;
+    let vew = (repredicted_vol - previous_variance) * expected_precision;
+    let d = mean - emean;
+    let vpe2 = (1.0 / prec + d * d) * expected_precision - 1.0;
+    let inner = eff2 + vew * vpe2;
+    let contrib = ((k * k) * eff2 * inner * 0.5).max(0.0);
+    ((ep + contrib).min(max_posterior_precision), posterior_mean_vol)
 }
 
 /// eHGF volatility-level posterior: mean first (using the expected precision),
@@ -102,48 +170,31 @@ fn volatility_posterior_ehgf(
     let vpe = state.volatility_prediction_error.as_ref().unwrap();
     let epv = state.expected_precision_vol.as_ref().unwrap();
     let emv = state.expected_mean_vol.as_ref().unwrap();
-
-    // Mean first, using expected_precision_vol as the approximation.
-    let posterior_mean_vol = ndarray::Zip::from(emv)
-        .and(kappa)
-        .and(eff)
-        .and(vpe)
-        .and(epv)
-        .map_collect(|&m, &k, &g, &dpe, &ep| m + (k * g * dpe) / (ep * 2.0));
-
-    // Safe precision update: recompute the effective precision from the updated
-    // mean and floor the increment at zero. Nine per-element inputs (beyond
-    // `Zip`'s 6-array limit), so a single indexed loop with one output buffer.
     let cond = &state.conditional_expected_precision;
     let prec = &state.precision;
     let mean = &state.mean;
     let emean = &state.expected_mean;
-    // Plain exponentials: the JAX eHGF posterior applies no underflow guard
-    // here (unlike the prediction kernels' `guarded_volatility`); the only
-    // floor is the `1e-128` clamp on `previous_variance` below. The per-node
-    // backend's eHGF update follows the same convention.
-    let pvol = |exponent: f64| time_step * exponent.exp();
+
     let n = mean.len();
     let mut posterior_precision_vol = Array1::<f64>::zeros(n);
+    let mut posterior_mean_vol = Array1::<f64>::zeros(n);
     for i in 0..n {
-        let k = kappa[i];
-        let t = tonic[i];
-        let em = emv[i];
-        let ep = epv[i];
-        // Reconstruct the value level's pre-prediction variance exactly.
-        let mgf = (k * k) / (ep * 2.0);
-        let predicted_vol = pvol(t + k * em + mgf);
-        let previous_variance = (1.0 / cond[i] - predicted_vol).max(1e-128);
-        // Re-predict volatility / precision from the posterior mean.
-        let repredicted_vol = pvol(k * posterior_mean_vol[i] + t);
-        let expected_precision = 1.0 / (previous_variance + repredicted_vol);
-        let eff2 = repredicted_vol * expected_precision;
-        let vew = (repredicted_vol - previous_variance) * expected_precision;
-        let d = mean[i] - emean[i];
-        let vpe2 = (1.0 / prec[i] + d * d) * expected_precision - 1.0;
-        let inner = eff2 + vew * vpe2;
-        let contrib = ((k * k) * eff2 * inner * 0.5).max(0.0);
-        posterior_precision_vol[i] = (ep + contrib).min(max_posterior_precision);
+        let (pp, m) = ehgf_vol_node(
+            kappa[i],
+            tonic[i],
+            emv[i],
+            epv[i],
+            eff[i],
+            vpe[i],
+            cond[i],
+            prec[i],
+            mean[i],
+            emean[i],
+            time_step,
+            max_posterior_precision,
+        );
+        posterior_precision_vol[i] = pp;
+        posterior_mean_vol[i] = m;
     }
 
     state.precision_vol = Some(posterior_precision_vol);
@@ -171,87 +222,116 @@ fn volatility_posterior_unbounded(
     let emv = state.expected_mean_vol.as_ref().unwrap();
     let cond = &state.conditional_expected_precision;
 
-    let log_time_step = time_step.ln();
-    let log_float_max = f64::MAX.ln();
-
     let n = state.mean.len();
     let mut posterior_mean_vol = Array1::<f64>::zeros(n);
     let mut posterior_precision_vol = Array1::<f64>::zeros(n);
     for i in 0..n {
-        let k = kappa[i];
-        let t = tonic[i];
-        let em = emv[i];
-        let ep = epv[i];
-
-        // Reconstruct the pre-prediction variance exactly from the conditional
-        // predicted precision (the prediction's full exponent, MGF included).
-        let predicted_volatility = time_step * (t + k * em + (k * k) / (2.0 * ep)).exp();
-        let previous_variance = (1.0 / cond[i] - predicted_volatility).max(1e-128);
-        let d = state.mean[i] - state.expected_mean[i];
-        let be_aux = 1.0 / state.precision[i] + d * d;
-
-        let log_previous_variance = previous_variance.ln();
-        // Canonical exponent at prediction.
-        let gamma_c = log_time_step + k * em + t;
-        // w_jm1 = 1/(1 + previous_variance/exp(γ)) = sigmoid(γ − log α).
-        let w_jm1 = sigmoid(gamma_c - log_previous_variance);
-        // Volatility PE with the *marginal* predicted precision.
-        let da_jm1 = state.expected_precision[i] * be_aux - 1.0;
-
-        // Expansion 1: quadratic at the prediction (prior mean).
-        let pi1 = ep + 0.5 * k * k * w_jm1 * (1.0 - w_jm1);
-        let mu1 = em + (k * w_jm1 / (2.0 * pi1)) * da_jm1;
-
-        // Expansion 2: quadratic at the Lambert-W approximate mode.
-        let pihat_y = ep / (k * k);
-        let log_w_arg = be_aux.ln() - (2.0 * pihat_y).ln() + 0.5 / pihat_y - gamma_c;
-        let w_arg = log_w_arg.min(log_float_max).exp();
-        let v_w = lambert_w0(w_arg);
-        let y_star = gamma_c + v_w - 0.5 / pihat_y;
-        let x_star = (y_star - log_time_step - t) / k;
-
-        let log_s2 = log_time_step + k * x_star + t;
-        let log_denom_s = logaddexp(log_previous_variance, log_s2);
-        let w2 = sigmoid(log_s2 - log_previous_variance);
-        let da2 = be_aux * (-log_denom_s).exp() - 1.0;
-
-        let pi2_full = ep + 0.5 * k * k * w2 * (w2 + (2.0 * w2 - 1.0) * da2);
-        let pi2_safe = if pi2_full <= 0.0 {
-            ep + 0.5 * k * k * w2 * (1.0 - w2)
-        } else {
-            pi2_full
-        };
-        let mu2_safe = x_star + (0.5 * k * w2 * da2 - ep * (x_star - em)) / pi2_safe;
-
-        // Fall back to Expansion 1 if Expansion 2 is non-finite.
-        let (pi2, mu2) = if pi2_safe.is_finite() && mu2_safe.is_finite() {
-            (pi2_safe, mu2_safe)
-        } else {
-            (pi1, mu1)
-        };
-
-        // Variational energy-based softmax blend (log-space form).
-        let log_ey1 = log_time_step + k * mu1 + t;
-        let log_denom_1 = logaddexp(log_previous_variance, log_ey1);
-        let i1 = -0.5 * log_denom_1
-            - 0.5 * be_aux * (-log_denom_1).exp()
-            - 0.5 * ep * (mu1 - em) * (mu1 - em);
-        let log_ey2 = log_time_step + k * mu2 + t;
-        let log_denom_2 = logaddexp(log_previous_variance, log_ey2);
-        let i2 = -0.5 * log_denom_2
-            - 0.5 * be_aux * (-log_denom_2).exp()
-            - 0.5 * ep * (mu2 - em) * (mu2 - em);
-        let b = sigmoid(i2 - i1);
-
-        // Gaussian mixture moment matching.
-        let mu = (1.0 - b) * mu1 + b * mu2;
-        let sig2 = (1.0 - b) / pi1 + b / pi2 + b * (1.0 - b) * (mu1 - mu2) * (mu1 - mu2);
-        posterior_mean_vol[i] = mu;
-        posterior_precision_vol[i] = (1.0 / sig2).min(max_posterior_precision);
+        let (pp, m) = unbounded_vol_node(
+            kappa[i],
+            tonic[i],
+            emv[i],
+            epv[i],
+            cond[i],
+            state.expected_precision[i],
+            state.precision[i],
+            state.mean[i],
+            state.expected_mean[i],
+            time_step,
+            max_posterior_precision,
+        );
+        posterior_precision_vol[i] = pp;
+        posterior_mean_vol[i] = m;
     }
 
     state.precision_vol = Some(posterior_precision_vol);
     state.mean_vol = Some(posterior_mean_vol);
+}
+
+/// Unbounded (uHGF) volatility-level posterior of one node; see
+/// [`volatility_posterior_unbounded`] for the scheme. Returns
+/// `(precision_vol, mean_vol)`.
+#[inline]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn unbounded_vol_node(
+    k: f64,
+    t: f64,
+    em: f64,
+    ep: f64,
+    cond: f64,
+    marginal_ep: f64,
+    prec: f64,
+    mean: f64,
+    emean: f64,
+    time_step: f64,
+    max_posterior_precision: f64,
+) -> (f64, f64) {
+    let log_time_step = time_step.ln();
+    let log_float_max = f64::MAX.ln();
+
+    // Reconstruct the pre-prediction variance exactly from the conditional
+    // predicted precision (the prediction's full exponent, MGF included).
+    let predicted_volatility = time_step * (t + k * em + (k * k) / (2.0 * ep)).exp();
+    let previous_variance = (1.0 / cond - predicted_volatility).max(1e-128);
+    let d = mean - emean;
+    let be_aux = 1.0 / prec + d * d;
+
+    let log_previous_variance = previous_variance.ln();
+    // Canonical exponent at prediction.
+    let gamma_c = log_time_step + k * em + t;
+    // w_jm1 = 1/(1 + previous_variance/exp(γ)) = sigmoid(γ − log α).
+    let w_jm1 = sigmoid(gamma_c - log_previous_variance);
+    // Volatility PE with the *marginal* predicted precision.
+    let da_jm1 = marginal_ep * be_aux - 1.0;
+
+    // Expansion 1: quadratic at the prediction (prior mean).
+    let pi1 = ep + 0.5 * k * k * w_jm1 * (1.0 - w_jm1);
+    let mu1 = em + (k * w_jm1 / (2.0 * pi1)) * da_jm1;
+
+    // Expansion 2: quadratic at the Lambert-W approximate mode.
+    let pihat_y = ep / (k * k);
+    let log_w_arg = be_aux.ln() - (2.0 * pihat_y).ln() + 0.5 / pihat_y - gamma_c;
+    let w_arg = log_w_arg.min(log_float_max).exp();
+    let v_w = lambert_w0(w_arg);
+    let y_star = gamma_c + v_w - 0.5 / pihat_y;
+    let x_star = (y_star - log_time_step - t) / k;
+
+    let log_s2 = log_time_step + k * x_star + t;
+    let log_denom_s = logaddexp(log_previous_variance, log_s2);
+    let w2 = sigmoid(log_s2 - log_previous_variance);
+    let da2 = be_aux * (-log_denom_s).exp() - 1.0;
+
+    let pi2_full = ep + 0.5 * k * k * w2 * (w2 + (2.0 * w2 - 1.0) * da2);
+    let pi2_safe = if pi2_full <= 0.0 {
+        ep + 0.5 * k * k * w2 * (1.0 - w2)
+    } else {
+        pi2_full
+    };
+    let mu2_safe = x_star + (0.5 * k * w2 * da2 - ep * (x_star - em)) / pi2_safe;
+
+    // Fall back to Expansion 1 if Expansion 2 is non-finite.
+    let (pi2, mu2) = if pi2_safe.is_finite() && mu2_safe.is_finite() {
+        (pi2_safe, mu2_safe)
+    } else {
+        (pi1, mu1)
+    };
+
+    // Variational energy-based softmax blend (log-space form).
+    let log_ey1 = log_time_step + k * mu1 + t;
+    let log_denom_1 = logaddexp(log_previous_variance, log_ey1);
+    let i1 = -0.5 * log_denom_1
+        - 0.5 * be_aux * (-log_denom_1).exp()
+        - 0.5 * ep * (mu1 - em) * (mu1 - em);
+    let log_ey2 = log_time_step + k * mu2 + t;
+    let log_denom_2 = logaddexp(log_previous_variance, log_ey2);
+    let i2 = -0.5 * log_denom_2
+        - 0.5 * be_aux * (-log_denom_2).exp()
+        - 0.5 * ep * (mu2 - em) * (mu2 - em);
+    let b = sigmoid(i2 - i1);
+
+    // Gaussian mixture moment matching.
+    let mu = (1.0 - b) * mu1 + b * mu2;
+    let sig2 = (1.0 - b) / pi1 + b / pi2 + b * (1.0 - b) * (mu1 - mu2) * (mu1 - mu2);
+    ((1.0 / sig2).min(max_posterior_precision), mu)
 }
 
 #[cfg(test)]

--- a/src/vectorised/batched.rs
+++ b/src/vectorised/batched.rs
@@ -1,0 +1,730 @@
+//! Batch-synchronous sweeps over all samples at once, in a features × samples
+//! layout: every phase of [`crate::vectorised::network::DeepNet::batch_update`]
+//! is one `gemm` per layer instead of one `gemv` per layer per sample.
+//!
+//! Each sample of a batch starts from the same state template, so the whole
+//! batch can be swept together: a [`BatchedLayerState`] holds every
+//! [`LayerState`] field with a trailing samples axis (shape
+//! `(n_nodes, n_samples)`), and the kernels below mirror the per-sample
+//! kernels of [`crate::updates::vectorised`] term for term. Elementwise
+//! formulas are shared with the per-sample path through the per-node scalar
+//! functions of [`crate::updates::vectorised::volatile::prediction_error`],
+//! so the two paths cannot drift; only the weight contractions change, from
+//! matrix-vector to matrix-matrix products.
+
+use crate::math::sigmoid;
+use crate::updates::vectorised::learning::WeightKind;
+use crate::updates::vectorised::softmax_inplace;
+use crate::updates::vectorised::volatile::guarded_volatility;
+use crate::updates::vectorised::volatile::prediction_error::{
+    ehgf_vol_node, standard_vol_node, unbounded_vol_node, volatility_pe_node,
+};
+use crate::vectorised::layer::{DeepNet, Layer, LayerKind, LayerState, VolatilityUpdate};
+use crate::vectorised::mat::{Matrix, Vector};
+use ndarray::parallel::prelude::*;
+use ndarray::{s, ArrayView2, Axis, Zip};
+
+/// A [`LayerState`] with a trailing samples axis: every field is a
+/// `(n_nodes, n_samples)` matrix, one column per sample. The
+/// `effective_precision_vol` and `volatility_prediction_error` fields are
+/// omitted: nothing in the batch step reads them (the volatility prediction
+/// error is consumed inline by the volatility posterior).
+pub struct BatchedLayerState {
+    pub mean: Matrix,
+    pub precision: Matrix,
+    pub expected_mean: Matrix,
+    pub expected_precision: Matrix,
+    pub conditional_expected_precision: Matrix,
+    pub effective_precision: Matrix,
+    pub value_prediction_error: Matrix,
+    pub mean_vol: Option<Matrix>,
+    pub precision_vol: Option<Matrix>,
+    pub expected_mean_vol: Option<Matrix>,
+    pub expected_precision_vol: Option<Matrix>,
+}
+
+/// Repeat a per-node vector across `n_samples` columns.
+fn tile(v: &Vector, n_samples: usize) -> Matrix {
+    v.view()
+        .insert_axis(Axis(1))
+        .broadcast((v.len(), n_samples))
+        .expect("broadcast to (n, samples)")
+        .to_owned()
+}
+
+impl BatchedLayerState {
+    /// Broadcast a state template to `n_samples` identical columns; the
+    /// starting point of every batch step.
+    ///
+    /// Only the fields the sweeps read before writing carry the template
+    /// values: the value-level posterior precision (every layer), the
+    /// marginal predicted precision (read on the clamped top layer, which is
+    /// never predicted), and the volatility level's belief. Every other field
+    /// is written by the sweeps before it is read, so it starts as a zeroed
+    /// allocation the copy never has to touch.
+    pub fn from_template(state: &LayerState, n_samples: usize) -> Self {
+        let n = state.n_nodes();
+        let z = || Matrix::zeros((n, n_samples));
+        Self {
+            mean: z(),
+            precision: tile(&state.precision, n_samples),
+            expected_mean: z(),
+            expected_precision: tile(&state.expected_precision, n_samples),
+            conditional_expected_precision: z(),
+            effective_precision: z(),
+            value_prediction_error: z(),
+            mean_vol: state.mean_vol.as_ref().map(|v| tile(v, n_samples)),
+            precision_vol: state.precision_vol.as_ref().map(|v| tile(v, n_samples)),
+            expected_mean_vol: state.expected_mean_vol.as_ref().map(|_| z()),
+            expected_precision_vol: state.expected_precision_vol.as_ref().map(|_| z()),
+        }
+    }
+
+    fn n_samples(&self) -> usize {
+        self.mean.ncols()
+    }
+}
+
+/// Coupled parent activations for the whole batch: `g(μ̂_parent)` with a
+/// trailing bias row of ones, shape `(n_parent[+1], n_samples)`. Every entry
+/// is written exactly once (activation rows by the coupling pass, the bias
+/// row by a fill), so the zeroed allocation is never touched twice.
+fn coupled_activations(
+    parent_field: &Matrix,
+    coupling_fn: &'static crate::math::CouplingFn,
+    parent_has_constant: bool,
+) -> Matrix {
+    let (n_parent, n_samples) = parent_field.dim();
+    let rows = n_parent + usize::from(parent_has_constant);
+    let mut coupled = Matrix::zeros((rows, n_samples));
+    crate::math::with_coupling!(coupling_fn, |f, _df, _d2f| {
+        Zip::from(coupled.slice_mut(s![..n_parent, ..]))
+            .and(parent_field)
+            .for_each(|c, &m| *c = f(m));
+    });
+    if parent_has_constant {
+        coupled.row_mut(n_parent).fill(1.0);
+    }
+    coupled
+}
+
+/// Predict a volatile child layer from its parent for the whole batch,
+/// mirroring the per-sample `layer_prediction`.
+#[allow(clippy::too_many_arguments)]
+fn batched_volatile_prediction(
+    child: &mut BatchedLayerState,
+    child_layer: &Layer,
+    parent: &BatchedLayerState,
+    weights: &Matrix,
+    parent_layer: &Layer,
+    time_step: f64,
+) {
+    let params = &child_layer.params;
+    let (n, n_samples) = child.mean.dim();
+    let n_parent = parent.expected_mean.nrows();
+    let p = weights.ncols();
+
+    // 1. Volatility level (internal): the same elementwise formulas as the
+    // per-sample kernel, over every column at once.
+    if child_layer.has_volatility_parent {
+        let mean_vol = child.mean_vol.as_ref().expect("volatility mean");
+        let precision_vol = child.precision_vol.as_ref().expect("volatility precision");
+
+        let mut emv = Matrix::zeros((n, n_samples));
+        let mut epv = Matrix::zeros((n, n_samples));
+        Zip::from(emv.rows_mut())
+            .and(epv.rows_mut())
+            .and(mean_vol.rows())
+            .and(precision_vol.rows())
+            .and(&params.autoconnection_strength_vol)
+            .and(&params.tonic_volatility_vol)
+            .for_each(|mut em_row, mut ep_row, mv, pv, &a, &tvv| {
+                let pvv = guarded_volatility(tvv, time_step);
+                Zip::from(&mut em_row)
+                    .and(&mut ep_row)
+                    .and(&mv)
+                    .and(&pv)
+                    .for_each(|em, ep, &m, &pv_prec| {
+                        *em = a * m;
+                        *ep = 1.0 / (1.0 / pv_prec + pvv);
+                    });
+            });
+        child.expected_mean_vol = Some(emv);
+        child.expected_precision_vol = Some(epv);
+    }
+
+    // 2. Value level: coupled activations and the per-parent Laplace variance
+    // factor (t·g'(μ̂))² / π̃_parent (the bias row stays 0 there).
+    let coupled = coupled_activations(
+        &parent.expected_mean,
+        parent_layer.coupling_fn,
+        parent_layer.add_constant_input,
+    );
+    let mut ppv = Matrix::zeros((p, n_samples));
+    crate::math::with_coupling!(parent_layer.coupling_fn, |_f, df, _d2f| {
+        Zip::from(ppv.slice_mut(s![..n_parent, ..]))
+            .and(&parent.expected_mean)
+            .and(&parent.expected_precision)
+            .for_each(|o, &mu, &ep| {
+                let num = time_step * df(mu);
+                *o = (num * num) / ep;
+            });
+    });
+
+    // Mean prediction: one gemm over the whole batch.
+    child.expected_mean = weights.dot(&coupled);
+
+    // Laplace value-coupling variance: W² @ ppv, one gemm.
+    let w2 = weights.mapv(|w| w * w);
+    let value_coupling_variance = w2.dot(&ppv);
+
+    // Conditional (π̂), marginal (π̃), and effective (γ) predicted precisions,
+    // fused into a single pass over the state: π̂ = 1/(1/π + Ω),
+    // π̃ = 1/(1/π̂ + value_coupling_variance), γ = Ω·π̃, with
+    // Ω = t·exp(ω + κ·μ_vol + κ²/(2·π̂_vol)) the predicted volatility.
+    let precision_triple = |c: &mut f64, e: &mut f64, ef: &mut f64, pr: f64, pv: f64, v: f64| {
+        *c = 1.0 / (1.0 / pr + pv);
+        *e = 1.0 / (1.0 / *c + v);
+        *ef = pv * *e;
+    };
+    if child_layer.is_input_layer {
+        // Input/leaf override: no random walk between observations.
+        child
+            .conditional_expected_precision
+            .assign(&child.precision);
+        child.expected_precision.assign(&child.precision);
+        child.effective_precision.fill(0.0);
+    } else if child_layer.has_volatility_parent {
+        let emv = child.expected_mean_vol.as_ref().unwrap();
+        let epv = child.expected_precision_vol.as_ref().unwrap();
+        let mut predicted_vol = Matrix::zeros((n, n_samples));
+        Zip::from(predicted_vol.rows_mut())
+            .and(emv.rows())
+            .and(epv.rows())
+            .and(&params.tonic_volatility)
+            .and(&params.volatility_coupling)
+            .for_each(|mut out, em, ep, &t, &k| {
+                Zip::from(&mut out).and(&em).and(&ep).for_each(|o, &m, &pvv| {
+                    *o = guarded_volatility(t + k * m + (k * k) / (pvv * 2.0), time_step);
+                });
+            });
+        Zip::from(&mut child.conditional_expected_precision)
+            .and(&mut child.expected_precision)
+            .and(&mut child.effective_precision)
+            .and(&child.precision)
+            .and(&predicted_vol)
+            .and(&value_coupling_variance)
+            .for_each(|c, e, ef, &pr, &pv, &v| precision_triple(c, e, ef, pr, pv, v));
+    } else {
+        // Without a volatility level Ω is per node, not per sample: no tiled
+        // matrix, one row scalar each.
+        let per_node = params
+            .tonic_volatility
+            .mapv(|t| guarded_volatility(t, time_step));
+        Zip::from(child.conditional_expected_precision.rows_mut())
+            .and(child.expected_precision.rows_mut())
+            .and(child.effective_precision.rows_mut())
+            .and(child.precision.rows())
+            .and(value_coupling_variance.rows())
+            .and(&per_node)
+            .for_each(|mut crow, mut erow, mut efrow, prow, vrow, &pv| {
+                Zip::from(&mut crow)
+                    .and(&mut erow)
+                    .and(&mut efrow)
+                    .and(&prow)
+                    .and(&vrow)
+                    .for_each(|c, e, ef, &pr, &v| precision_triple(c, e, ef, pr, pv, v));
+            });
+    }
+}
+
+/// Predict a binary leaf layer for the whole batch, mirroring the per-sample
+/// `binary_prediction`.
+fn batched_binary_prediction(
+    child: &mut BatchedLayerState,
+    parent: &BatchedLayerState,
+    weights: &Matrix,
+    parent_layer: &Layer,
+    precision_clipping_value: f64,
+) {
+    let coupled = coupled_activations(
+        &parent.expected_mean,
+        parent_layer.coupling_fn,
+        parent_layer.add_constant_input,
+    );
+    let mut logit = weights.dot(&coupled);
+    logit.mapv_inplace(|x| {
+        sigmoid(x).clamp(precision_clipping_value, 1.0 - precision_clipping_value)
+    });
+    let expected_precision = logit.mapv(|m| m * (1.0 - m));
+    child.expected_mean = logit;
+    child.conditional_expected_precision = expected_precision.clone();
+    child.expected_precision = expected_precision;
+}
+
+/// Predict a categorical leaf layer for the whole batch, mirroring the
+/// per-sample `categorical_prediction` (one softmax per sample column).
+fn batched_categorical_prediction(
+    child: &mut BatchedLayerState,
+    parent: &BatchedLayerState,
+    weights: &Matrix,
+    parent_layer: &Layer,
+) {
+    let coupled = coupled_activations(
+        &parent.expected_mean,
+        parent_layer.coupling_fn,
+        parent_layer.add_constant_input,
+    );
+    let mut logits = weights.dot(&coupled);
+    for col in logits.columns_mut() {
+        softmax_inplace(col);
+    }
+    child.expected_mean = logits;
+    child.expected_precision.fill(1.0);
+    child.conditional_expected_precision.fill(1.0);
+    child.effective_precision.fill(0.0);
+}
+
+/// Prediction errors and the volatility-level posterior for a layer, over the
+/// whole batch; mirrors the per-sample `layer_prediction_error` (with the
+/// binary and categorical leaf variants folded in via the layer kind).
+fn batched_prediction_error(
+    layer_state: &mut BatchedLayerState,
+    layer: &Layer,
+    volatility_updates: VolatilityUpdate,
+    time_step: f64,
+    max_posterior_precision: f64,
+) {
+    match layer.kind {
+        LayerKind::Binary => {
+            // δ = (mean − μ̂) / π̂, posterior precision = expected precision.
+            Zip::from(&mut layer_state.value_prediction_error)
+                .and(&layer_state.mean)
+                .and(&layer_state.expected_mean)
+                .and(&layer_state.expected_precision)
+                .for_each(|d, &m, &em, &ep| *d = (m - em) / ep);
+            layer_state.precision.assign(&layer_state.expected_precision);
+            return;
+        }
+        LayerKind::Categorical => {
+            Zip::from(&mut layer_state.value_prediction_error)
+                .and(&layer_state.mean)
+                .and(&layer_state.expected_mean)
+                .for_each(|d, &m, &em| *d = m - em);
+            layer_state.precision.assign(&layer_state.expected_precision);
+            return;
+        }
+        LayerKind::Volatile => {}
+    }
+
+    // Value prediction error (always).
+    Zip::from(&mut layer_state.value_prediction_error)
+        .and(&layer_state.mean)
+        .and(&layer_state.expected_mean)
+        .for_each(|d, &m, &em| *d = m - em);
+
+    if !layer.has_volatility_parent {
+        return;
+    }
+
+    // Volatility PE and the volatility-level posterior, node by node, sample
+    // by sample, through the same scalar functions as the per-sample path.
+    // This is the transcendental-heavy part of the batch step (several
+    // exponentials, and a Lambert-W solve in the unbounded scheme, per node
+    // per sample), so the node rows run in parallel; every row's samples are
+    // contiguous in the row-major layout.
+    let (n, n_samples) = layer_state.mean.dim();
+    let params = &layer.params;
+    let emv = layer_state.expected_mean_vol.as_ref().expect("volatility level");
+    let epv = layer_state
+        .expected_precision_vol
+        .as_ref()
+        .expect("volatility level");
+    let mut new_precision_vol = Matrix::zeros((n, n_samples));
+    let mut new_mean_vol = Matrix::zeros((n, n_samples));
+    let mean = &layer_state.mean;
+    let expected_mean = &layer_state.expected_mean;
+    let precision = &layer_state.precision;
+    let expected_precision = &layer_state.expected_precision;
+    let conditional = &layer_state.conditional_expected_precision;
+    let effective = &layer_state.effective_precision;
+    new_precision_vol
+        .outer_iter_mut()
+        .into_par_iter()
+        .zip(new_mean_vol.outer_iter_mut().into_par_iter())
+        .enumerate()
+        .for_each(|(i, (mut pv_row, mut mv_row))| {
+            let k = params.volatility_coupling[i];
+            let t = params.tonic_volatility[i];
+            for j in 0..n_samples {
+                let dpe = volatility_pe_node(
+                    expected_precision[[i, j]],
+                    precision[[i, j]],
+                    mean[[i, j]],
+                    expected_mean[[i, j]],
+                );
+                let (pp, m) = match volatility_updates {
+                    VolatilityUpdate::Standard => standard_vol_node(
+                        k,
+                        effective[[i, j]],
+                        dpe,
+                        epv[[i, j]],
+                        emv[[i, j]],
+                        max_posterior_precision,
+                    ),
+                    VolatilityUpdate::EHgf => ehgf_vol_node(
+                        k,
+                        t,
+                        emv[[i, j]],
+                        epv[[i, j]],
+                        effective[[i, j]],
+                        dpe,
+                        conditional[[i, j]],
+                        precision[[i, j]],
+                        mean[[i, j]],
+                        expected_mean[[i, j]],
+                        time_step,
+                        max_posterior_precision,
+                    ),
+                    VolatilityUpdate::Unbounded => unbounded_vol_node(
+                        k,
+                        t,
+                        emv[[i, j]],
+                        epv[[i, j]],
+                        conditional[[i, j]],
+                        expected_precision[[i, j]],
+                        precision[[i, j]],
+                        mean[[i, j]],
+                        expected_mean[[i, j]],
+                        time_step,
+                        max_posterior_precision,
+                    ),
+                };
+                pv_row[j] = pp;
+                mv_row[j] = m;
+            }
+        });
+    layer_state.precision_vol = Some(new_precision_vol);
+    layer_state.mean_vol = Some(new_mean_vol);
+}
+
+/// The per-sample smoothing gain and effective (Schur-corrected) precision of
+/// a child layer, `(gain, eff)`, each `(n_child, n_samples)`: the same
+/// scalars the per-sample posterior forms on the fly.
+fn gain_and_effective(child: &BatchedLayerState, child_is_input_layer: bool) -> (Matrix, Matrix) {
+    let dim = child.mean.raw_dim();
+    let mut gain = Matrix::zeros(dim);
+    let mut eff = Matrix::zeros(dim);
+    Zip::from(&mut gain)
+        .and(&mut eff)
+        .and(&child.conditional_expected_precision)
+        .and(&child.precision)
+        .and(&child.expected_precision)
+        .for_each(|g, e, &cep, &prec, &ep| {
+            let pi_y = prec - ep;
+            // Leaf children short-circuit to the canonical predicted precision.
+            *e = if child_is_input_layer {
+                cep
+            } else {
+                cep * pi_y / (cep + pi_y)
+            };
+            *g = cep * prec / (cep + pi_y);
+        });
+    (gain, eff)
+}
+
+/// Value-level posterior (precision then mean) of a parent layer from its
+/// child's prediction errors, over the whole batch; mirrors the per-sample
+/// `layer_posterior_update` with the three weight contractions as gemms.
+fn batched_posterior_update(
+    parent: &mut BatchedLayerState,
+    child: &BatchedLayerState,
+    weights: &Matrix,
+    parent_layer: &Layer,
+    max_posterior_precision: f64,
+    child_is_input_layer: bool,
+) {
+    let ncols = weights.ncols();
+    let w = if parent_layer.add_constant_input {
+        weights.slice(s![.., ..ncols - 1])
+    } else {
+        weights.view()
+    };
+    let w2 = w.mapv(|x| x * x);
+
+    let (gain, eff) = gain_and_effective(child, child_is_input_layer);
+    let gd = &gain * &child.value_prediction_error;
+
+    // The weight contractions, one gemm each over the whole batch.
+    let pc1_base = w2.t().dot(&eff);
+    let msg = w.t().dot(&gd);
+
+    if parent_layer.coupling_fn.kind == crate::math::CouplingKind::Linear {
+        // Linear coupling: g' ≡ 1 and g'' ≡ 0, so the curvature term of the
+        // precision update vanishes with its gemm, and no derivative matrices
+        // are needed.
+        Zip::from(&mut parent.precision)
+            .and(&parent.expected_precision)
+            .and(&pc1_base)
+            .for_each(|p, &ep, &b| *p = (ep + b).max(ep).min(max_posterior_precision));
+        Zip::from(&mut parent.mean)
+            .and(&parent.expected_mean)
+            .and(&msg)
+            .and(&parent.precision)
+            .for_each(|m, &em, &mg, &pp| *m = em + mg / pp);
+        return;
+    }
+
+    let (mut coupling_prime, mut coupling_second) = {
+        let dim = parent.expected_mean.raw_dim();
+        (Matrix::zeros(dim), Matrix::zeros(dim))
+    };
+    crate::math::with_coupling!(parent_layer.coupling_fn, |_f, df, d2f| {
+        Zip::from(&mut coupling_prime)
+            .and(&mut coupling_second)
+            .and(&parent.expected_mean)
+            .for_each(|p, sec, &m| {
+                *p = df(m);
+                *sec = d2f(m);
+            });
+    });
+
+    let ed = &eff * &child.value_prediction_error;
+    let sum_pi_vpe = w.t().dot(&ed);
+
+    // Precision: clip(π̃_b + pc1·g'² − g''·(Wᵀ@(eff∘δ))).
+    Zip::from(&mut parent.precision)
+        .and(&parent.expected_precision)
+        .and(&pc1_base)
+        .and(&sum_pi_vpe)
+        .and(&coupling_prime)
+        .and(&coupling_second)
+        .for_each(|p, &ep, &b, &spv, &gp, &gs| {
+            let raw = ep + b * (gp * gp) - gs * spv;
+            *p = raw.max(ep).min(max_posterior_precision);
+        });
+
+    // Mean: μ̂_b + (Wᵀ@(g_a∘δ))·g'/π_b (reads the new precision).
+    Zip::from(&mut parent.mean)
+        .and(&parent.expected_mean)
+        .and(&msg)
+        .and(&coupling_prime)
+        .and(&parent.precision)
+        .for_each(|m, &em, &mg, &gp, &pp| {
+            *m = em + mg * gp / pp;
+        });
+}
+
+/// Top-down prediction sweep for the whole batch: clamp the predictors
+/// (`x` is `(n_samples, top_size)`) on the top layer and predict every layer
+/// from the one above it. The batched twin of `DeepNet::prediction_sweep`.
+pub fn batched_prediction_sweep(
+    net: &DeepNet,
+    states: &mut [BatchedLayerState],
+    x: ArrayView2<f64>,
+    time_step: f64,
+) {
+    let n = net.layers.len();
+    // Clamp x (transposed to features × samples) on the top layer: one
+    // strided copy from the view, one contiguous copy between the fields.
+    let top = states.last_mut().expect("network has no layers");
+    top.expected_mean.assign(&x.t());
+    top.mean.assign(&top.expected_mean);
+
+    for i in (1..n).rev() {
+        let (lower, upper) = states.split_at_mut(i);
+        let child = &mut lower[i - 1];
+        let parent = &upper[0];
+        let child_layer = &net.layers[i - 1];
+        let parent_layer = &net.layers[i];
+        let weights = parent_layer
+            .weights_in
+            .as_ref()
+            .expect("parent has no weights");
+        match child_layer.kind {
+            LayerKind::Volatile => batched_volatile_prediction(
+                child,
+                child_layer,
+                parent,
+                weights,
+                parent_layer,
+                time_step,
+            ),
+            LayerKind::Binary => batched_binary_prediction(
+                child,
+                parent,
+                weights,
+                parent_layer,
+                net.precision_clipping_value,
+            ),
+            LayerKind::Categorical => {
+                batched_categorical_prediction(child, parent, weights, parent_layer)
+            }
+        }
+    }
+}
+
+/// Bottom-up update sweep for the whole batch: clamp the observations
+/// (`y` is `(n_samples, bottom_size)`), compute the leaf prediction error,
+/// then interleave posterior + prediction error over interior layers (the
+/// clamped top is not updated). The batched twin of `DeepNet::update_sweep`.
+pub fn batched_update_sweep(
+    net: &DeepNet,
+    states: &mut [BatchedLayerState],
+    y: ArrayView2<f64>,
+    time_step: f64,
+) {
+    let n = net.layers.len();
+    let vol = net.volatility_updates;
+    let max_pp = net.max_posterior_precision;
+
+    // Clamp observations and compute the leaf prediction error.
+    states[0].mean.assign(&y.t());
+    batched_prediction_error(&mut states[0], &net.layers[0], vol, time_step, max_pp);
+
+    // Interior posterior + PE, bottom-up (exclude the clamped top layer).
+    for i in 1..n.saturating_sub(1) {
+        let (lower, upper) = states.split_at_mut(i);
+        let child = &lower[i - 1];
+        let parent = &mut upper[0];
+        let parent_layer = &net.layers[i];
+        let weights = parent_layer
+            .weights_in
+            .as_ref()
+            .expect("parent has no weights");
+        batched_posterior_update(
+            parent,
+            child,
+            weights,
+            parent_layer,
+            max_pp,
+            net.layers[i - 1].is_input_layer,
+        );
+        batched_prediction_error(parent, parent_layer, vol, time_step, max_pp);
+    }
+}
+
+/// Per-sample prediction errors routed to the input (top) layer, shape
+/// `(n_top, n_samples)`: the batched twin of
+/// `DeepNet::input_prediction_error`, one gemm for the whole batch.
+pub fn batched_input_prediction_error(net: &DeepNet, states: &[BatchedLayerState]) -> Matrix {
+    let n = net.layers.len();
+    assert!(n >= 2, "input_prediction_error needs at least two layers");
+    let top_layer = &net.layers[n - 1];
+    let child = &states[n - 2];
+    let w = top_layer
+        .weights_in
+        .as_ref()
+        .expect("the top layer of a multi-layer network has weights");
+    // The bias column connects the constant node, not a real input.
+    let cols = w.ncols() - usize::from(top_layer.add_constant_input);
+    let w = w.slice(s![.., ..cols]);
+
+    // Smoothing gain of the child layer, identical to the gain of the
+    // interior posterior mean update, fused directly into the message:
+    // gain∘δ in one pass, no gain matrix materialised.
+    let mut message = Matrix::zeros(child.mean.raw_dim());
+    Zip::from(&mut message)
+        .and(&child.value_prediction_error)
+        .and(&child.conditional_expected_precision)
+        .and(&child.precision)
+        .and(&child.expected_precision)
+        .for_each(|out, &d, &cep, &prec, &ep| {
+            let pi_y = prec - ep;
+            *out = cep * prec / (cep + pi_y) * d;
+        });
+    let mut routed = w.t().dot(&message);
+    if top_layer.coupling_fn.kind != crate::math::CouplingKind::Linear {
+        crate::math::with_coupling!(top_layer.coupling_fn, |_f, df, _d2f| {
+            Zip::from(&mut routed)
+                .and(&states[n - 1].expected_mean)
+                .for_each(|r, &m| *r *= df(m));
+        });
+    }
+    routed
+}
+
+/// Batch-mean descent weight gradients, matched 1:1 to `net.layers` (`None`
+/// for the bottom layer). The per-sample rank-one factors of
+/// `weight_gradient_factors` become two factor matrices, and the batch mean
+/// of their outer products is a single contraction per layer:
+/// `mean_grad = U @ Vᵀ / n_samples`.
+pub fn batched_mean_weight_gradients(
+    net: &DeepNet,
+    states: &[BatchedLayerState],
+    kind: WeightKind,
+) -> Vec<Option<Matrix>> {
+    let n = net.layers.len();
+    let mut grads: Vec<Option<Matrix>> = Vec::with_capacity(n);
+    grads.push(None); // bottom layer has no incoming weights
+    for i in 1..n {
+        let parent_layer = &net.layers[i];
+        let child_layer = &net.layers[i - 1];
+        let parent = &states[i];
+        let child = &states[i - 1];
+        let n_samples = child.n_samples();
+
+        // Child-side factor u = -(δ [∘ π]) and parent-side factor
+        // v = g(parent posterior mean) with a bias row of ones, each built
+        // sanitized (non-finite entries zeroed) in a single pass.
+        let sanitize = |x: f64| if x.is_finite() { x } else { 0.0 };
+        let mut u = Matrix::zeros(child.value_prediction_error.raw_dim());
+        if kind == WeightKind::PrecisionWeighted && child_layer.kind != LayerKind::Binary {
+            Zip::from(&mut u)
+                .and(&child.value_prediction_error)
+                .and(&child.precision)
+                .for_each(|u, &d, &p| *u = sanitize(-d * p));
+        } else {
+            Zip::from(&mut u)
+                .and(&child.value_prediction_error)
+                .for_each(|u, &d| *u = sanitize(-d));
+        }
+        let n_parent = parent.mean.nrows();
+        let rows = n_parent + usize::from(parent_layer.add_constant_input);
+        let mut v = Matrix::zeros((rows, n_samples));
+        crate::math::with_coupling!(parent_layer.coupling_fn, |f, _df, _d2f| {
+            Zip::from(v.slice_mut(s![..n_parent, ..]))
+                .and(&parent.mean)
+                .for_each(|c, &m| *c = sanitize(f(m)));
+        });
+        if parent_layer.add_constant_input {
+            v.row_mut(n_parent).fill(1.0);
+        }
+
+        let mut grad = u.dot(&v.t());
+        grad.mapv_inplace(|g| g / n_samples as f64);
+        grads.push(Some(grad));
+    }
+    grads
+}
+
+/// Per-layer batch-mean increments of the carried confidence fields: the
+/// value-level posterior precision and, where present, the volatility
+/// level's belief `(mean_vol, precision_vol)`.
+pub type ConfidenceIncrements = Vec<(Vector, Option<(Vector, Vector)>)>;
+
+/// Batch-mean increments of the carried confidence fields relative to the
+/// template: `row_mean(field) − template`, per layer.
+pub fn batched_confidence_increments(
+    states: &[BatchedLayerState],
+    templates: &[&LayerState],
+) -> ConfidenceIncrements {
+    states
+        .iter()
+        .zip(templates.iter())
+        .map(|(state, template)| {
+            let precision = state.precision.mean_axis(Axis(1)).expect("non-empty batch")
+                - &template.precision;
+            let vol = template.mean_vol.as_ref().map(|template_mv| {
+                let mv = state.mean_vol.as_ref().expect("volatility level");
+                let pv = state.precision_vol.as_ref().expect("volatility level");
+                let template_pv = template.precision_vol.as_ref().expect("volatility level");
+                (
+                    mv.mean_axis(Axis(1)).expect("non-empty batch") - template_mv,
+                    pv.mean_axis(Axis(1)).expect("non-empty batch") - template_pv,
+                )
+            });
+            (precision, vol)
+        })
+        .collect()
+}

--- a/src/vectorised/mod.rs
+++ b/src/vectorised/mod.rs
@@ -5,6 +5,7 @@
 //! (`pyhgf/typing/vectorised.py` + `pyhgf/utils/vectorized_belief_propagation.py`
 //! vs `pyhgf/updates/vectorized/`).
 
+pub mod batched;
 pub mod layer;
 pub mod mat;
 pub mod network;

--- a/src/vectorised/network.rs
+++ b/src/vectorised/network.rs
@@ -189,6 +189,239 @@ impl DeepNet {
         output_pred
     }
 
+    /// Prediction error routed to the network's input (top) layer, mirroring
+    /// the JAX `input_prediction_error`.
+    ///
+    /// The bottom-up sweep never touches the top layer (its values are clamped
+    /// to the predictors), so this computes the error message the top layer
+    /// would receive from the layer below it: the child layer's value
+    /// prediction error, weighted by its smoothing gain (the same gain used by
+    /// the interior posterior mean update), routed back through the connecting
+    /// weights (bias column excluded) and scaled by the derivative of the top
+    /// layer's coupling function at the clamped predictors. Must run after
+    /// [`Self::update_sweep`], so the child layer carries its prediction
+    /// error. Panics if the network has a single layer (there is no layer
+    /// below the input layer to route an error from); the Python boundary
+    /// validates this.
+    pub fn input_prediction_error(&self) -> Vector {
+        let n = self.layers.len();
+        assert!(n >= 2, "input_prediction_error needs at least two layers");
+        let top = &self.layers[n - 1];
+        let child = &self.layers[n - 2].state;
+        let w = top
+            .weights_in
+            .as_ref()
+            .expect("the top layer of a multi-layer network has weights");
+        // The bias column connects the constant node, not a real input.
+        let cols = w.ncols() - usize::from(top.add_constant_input);
+        let w = w.slice(s![.., ..cols]);
+
+        // Smoothing gain of the child layer, identical to the gain of the
+        // interior posterior mean update, fused directly into the message so
+        // the top layer sees exactly the message any interior layer would see.
+        let mut message = Vector::zeros(child.mean.len());
+        ndarray::Zip::from(&mut message)
+            .and(&child.value_prediction_error)
+            .and(&child.conditional_expected_precision)
+            .and(&child.precision)
+            .and(&child.expected_precision)
+            .for_each(|out, &d, &cep, &prec, &ep| {
+                let pi_y = prec - ep;
+                *out = cep * prec / (cep + pi_y) * d;
+            });
+        let mut routed = w.t().dot(&message);
+        if top.coupling_fn.kind != crate::math::CouplingKind::Linear {
+            crate::math::with_coupling!(top.coupling_fn, |_f, df, _d2f| {
+                ndarray::Zip::from(&mut routed)
+                    .and(&top.state.expected_mean)
+                    .for_each(|r, &m| *r *= df(m));
+            });
+        }
+        routed
+    }
+
+    /// One batch-synchronous learning step over many samples at once,
+    /// mirroring the JAX `batch_step`.
+    ///
+    /// Every sample is processed from the same state template (same weights,
+    /// same confidences); the whole batch is swept together through the
+    /// batched kernels of [`crate::vectorised::batched`], so every phase is
+    /// one `gemm` per layer in a features × samples layout. The per-sample
+    /// weight gradients and confidence changes are averaged and applied once,
+    /// so the whole batch counts as a single observation. This differs from
+    /// [`Self::propagation_step`] driven sequentially, where the confidences
+    /// adapt from one sample to the next.
+    ///
+    /// With `optimizer` set, the batch-mean descent gradient drives one
+    /// optimiser step; with `None` the weights are frozen. With
+    /// `update_confidences`, the batch-mean change of the carried confidence
+    /// fields (the value-level posterior precision and the volatility level's
+    /// belief) is added to the template state; everything else is left on the
+    /// template, as the next batch's sweeps rewrite it anyway.
+    ///
+    /// Returns the per-sample prediction errors at the input layer, shape
+    /// `(n_samples, top_size)`; see [`Self::input_prediction_error`] for their
+    /// meaning and sign convention.
+    #[allow(clippy::too_many_arguments)]
+    pub fn batch_update(
+        &mut self,
+        x: ArrayView2<f64>,
+        y: ArrayView2<f64>,
+        optimizer: Option<&Optimizer>,
+        opt_state: Option<&mut OptState>,
+        time_step: f64,
+        learning_kind: WeightKind,
+        update_confidences: bool,
+    ) -> Matrix {
+        // Samples are exchangeable by construction, so the batch splits into
+        // per-thread slabs swept independently; small batches stay in one
+        // chunk and take exactly the single-threaded path.
+        const MIN_CHUNK: usize = 256;
+        let n_chunks = rayon::current_num_threads()
+            .min(x.nrows().div_ceil(MIN_CHUNK))
+            .max(1);
+        self.batch_update_chunked(
+            x,
+            y,
+            optimizer,
+            opt_state,
+            time_step,
+            learning_kind,
+            update_confidences,
+            n_chunks,
+        )
+    }
+
+    /// The chunked executor behind [`Self::batch_update`]: sweep each slab of
+    /// samples through the batched kernels in parallel, then combine the
+    /// per-chunk results (input-error slices concatenated; gradient and
+    /// confidence means weighted by chunk size) and apply them once.
+    #[allow(clippy::too_many_arguments)]
+    fn batch_update_chunked(
+        &mut self,
+        x: ArrayView2<f64>,
+        y: ArrayView2<f64>,
+        optimizer: Option<&Optimizer>,
+        opt_state: Option<&mut OptState>,
+        time_step: f64,
+        learning_kind: WeightKind,
+        update_confidences: bool,
+        n_chunks: usize,
+    ) -> Matrix {
+        use crate::vectorised::batched::{
+            batched_confidence_increments, batched_input_prediction_error,
+            batched_mean_weight_gradients, batched_prediction_sweep, batched_update_sweep,
+            BatchedLayerState, ConfidenceIncrements,
+        };
+        use crate::vectorised::layer::LayerState;
+        use rayon::prelude::*;
+
+        let n_samples = x.nrows();
+        let n_layers = self.layers.len();
+        let top_size = self.layers[n_layers - 1].n_nodes();
+        let learning = optimizer.is_some();
+
+        // Even sample ranges, the remainder spread over the first chunks.
+        let base = n_samples / n_chunks;
+        let remainder = n_samples % n_chunks;
+        let mut ranges = Vec::with_capacity(n_chunks);
+        let mut start = 0;
+        for c in 0..n_chunks {
+            let len = base + usize::from(c < remainder);
+            ranges.push(start..start + len);
+            start += len;
+        }
+
+        struct ChunkOut {
+            range: std::ops::Range<usize>,
+            errors: Matrix,
+            grads: Option<Vec<Option<Matrix>>>,
+            increments: Option<ConfidenceIncrements>,
+        }
+
+        let net: &DeepNet = self;
+        let templates: Vec<&LayerState> = net.layers.iter().map(|layer| &layer.state).collect();
+        let chunk_outs: Vec<ChunkOut> = ranges
+            .into_par_iter()
+            .map(|range| {
+                let mut states: Vec<BatchedLayerState> = templates
+                    .iter()
+                    .map(|state| BatchedLayerState::from_template(state, range.len()))
+                    .collect();
+                batched_prediction_sweep(
+                    net,
+                    &mut states,
+                    x.slice(s![range.clone(), ..]),
+                    time_step,
+                );
+                batched_update_sweep(net, &mut states, y.slice(s![range.clone(), ..]), time_step);
+                let errors = batched_input_prediction_error(net, &states);
+                let grads =
+                    learning.then(|| batched_mean_weight_gradients(net, &states, learning_kind));
+                let increments = update_confidences
+                    .then(|| batched_confidence_increments(&states, &templates));
+                ChunkOut {
+                    range,
+                    errors,
+                    grads,
+                    increments,
+                }
+            })
+            .collect();
+
+        let mut input_errors = Matrix::zeros((top_size, n_samples));
+        for chunk in &chunk_outs {
+            input_errors
+                .slice_mut(s![.., chunk.range.clone()])
+                .assign(&chunk.errors);
+        }
+
+        if let (Some(opt), Some(state)) = (optimizer, opt_state) {
+            // Batch mean = chunk means weighted by chunk size.
+            let mut grads: Vec<Option<Matrix>> = self
+                .layers
+                .iter()
+                .map(|layer| layer.weights_in.as_ref().map(|w| Matrix::zeros(w.raw_dim())))
+                .collect();
+            for chunk in &chunk_outs {
+                let weight = chunk.range.len() as f64 / n_samples as f64;
+                for (total, grad) in grads.iter_mut().zip(chunk.grads.as_ref().unwrap()) {
+                    if let (Some(total), Some(grad)) = (total.as_mut(), grad.as_ref()) {
+                        total.scaled_add(weight, grad);
+                    }
+                }
+            }
+            opt.apply_dense(state, &mut self.layers, &grads);
+        }
+
+        if update_confidences {
+            for (l, layer) in self.layers.iter_mut().enumerate() {
+                for chunk in &chunk_outs {
+                    let weight = chunk.range.len() as f64 / n_samples as f64;
+                    let (precision_inc, vol_inc) = &chunk.increments.as_ref().unwrap()[l];
+                    layer.state.precision.scaled_add(weight, precision_inc);
+                    if let Some((mean_vol_inc, precision_vol_inc)) = vol_inc {
+                        layer
+                            .state
+                            .mean_vol
+                            .as_mut()
+                            .expect("volatility level")
+                            .scaled_add(weight, mean_vol_inc);
+                        layer
+                            .state
+                            .precision_vol
+                            .as_mut()
+                            .expect("volatility level")
+                            .scaled_add(weight, precision_vol_inc);
+                    }
+                }
+            }
+        }
+
+        // Rows become samples again at the boundary (stride flip, no copy).
+        input_errors.reversed_axes()
+    }
+
     /// Batched, read-only forward pass over `n` samples at once.
     ///
     /// `x` is a `(n_samples, top_size)` view (borrowed directly from the numpy
@@ -271,7 +504,7 @@ mod tests {
                 ..LayerConfig::new(3)
             },
         ];
-        let mut net = DeepNet::from_configs(&configs).unwrap();
+        let net = DeepNet::from_configs(&configs).unwrap();
         let x = Matrix::from_shape_vec((1, 3), vec![1.0, 2.0, 3.0]).unwrap();
         let out = net.predict_batch(x.view());
         // weights_in on layer 1 is ones (2,3); each output = sum(x) = 6.
@@ -285,7 +518,7 @@ mod tests {
     #[test]
     fn test_predict_with_bias() {
         let configs = vec![LayerConfig::new(1), LayerConfig::new(2)];
-        let mut net = DeepNet::from_configs(&configs).unwrap();
+        let net = DeepNet::from_configs(&configs).unwrap();
         // weights_in on layer 1: shape (1, 2 + bias) = (1, 3), all ones.
         let x = Matrix::from_shape_vec((1, 2), vec![1.0, 4.0]).unwrap();
         let out = net.predict_batch(x.view());
@@ -332,6 +565,248 @@ mod tests {
         assert!(last < first);
     }
 
+    /// The batched (gemm) step reproduces the per-sample reference: sweeping
+    /// each sample from the template with the per-sample kernels, averaging
+    /// the rank-one gradients and the carried-field increments, and applying
+    /// both once. Covers a three-layer network with a nonlinear (tanh)
+    /// coupling, Adam, and confidence carrying.
+    #[test]
+    fn test_batch_update_matches_per_sample_reference() {
+        use crate::math::resolve_coupling_fn;
+
+        let make_net = || {
+            let configs = vec![
+                LayerConfig::new(2),
+                LayerConfig {
+                    coupling_fn: resolve_coupling_fn("tanh"),
+                    ..LayerConfig::new(4)
+                },
+                LayerConfig::new(3),
+            ];
+            let mut net = DeepNet::from_configs(&configs).unwrap();
+            // Deterministic, non-uniform weights.
+            for (l, layer) in net.layers.iter_mut().enumerate().skip(1) {
+                let w = layer.weights_in.as_mut().unwrap();
+                for ((i, j), v) in w.indexed_iter_mut() {
+                    *v = 0.3 * ((i + 2 * j + l) as f64 * 0.7).sin();
+                }
+            }
+            net
+        };
+
+        let n_samples = 5;
+        let x = Matrix::from_shape_fn((n_samples, 3), |(i, j)| ((i * 3 + j) as f64 * 0.9).cos());
+        let y = Matrix::from_shape_fn((n_samples, 2), |(i, j)| ((i * 2 + j) as f64 * 0.4).sin());
+        let opt = Optimizer::adam(0.01);
+
+        // Reference: the per-sample loop over the same template.
+        let mut reference = make_net();
+        let mut ref_state = OptState::init(&reference);
+        let template: Vec<_> = reference.layers.iter().map(|l| l.state.clone()).collect();
+        let n_layers = reference.layers.len();
+        let mut grad_sums: Vec<Option<Matrix>> = reference
+            .layers
+            .iter()
+            .map(|l| l.weights_in.as_ref().map(|w| Matrix::zeros(w.raw_dim())))
+            .collect();
+        let mut precision_sums: Vec<Vector> = template
+            .iter()
+            .map(|s| Vector::zeros(s.precision.len()))
+            .collect();
+        let mut vol_sums: Vec<(Vector, Vector)> = template
+            .iter()
+            .map(|s| {
+                let v = s.mean_vol.as_ref().unwrap();
+                (Vector::zeros(v.len()), Vector::zeros(v.len()))
+            })
+            .collect();
+        let mut ref_errors = Matrix::zeros((n_samples, 3));
+        for i in 0..n_samples {
+            for (layer, state) in reference.layers.iter_mut().zip(template.iter()) {
+                layer.state = state.clone();
+            }
+            reference.prediction_sweep(x.row(i), 1.0);
+            reference.update_sweep(y.row(i), 1.0);
+            ref_errors
+                .row_mut(i)
+                .assign(&reference.input_prediction_error());
+            let factors = reference.weight_gradient_factors(WeightKind::PrecisionWeighted);
+            for (sum, factor) in grad_sums.iter_mut().zip(factors.iter()) {
+                if let (Some(g), Some((u, v))) = (sum.as_mut(), factor.as_ref()) {
+                    for (r, &ui) in u.iter().enumerate() {
+                        for (c, &vj) in v.iter().enumerate() {
+                            g[[r, c]] += ui * vj;
+                        }
+                    }
+                }
+            }
+            for l in 0..n_layers {
+                let state = &reference.layers[l].state;
+                precision_sums[l] += &(&state.precision - &template[l].precision);
+                vol_sums[l].0 +=
+                    &(state.mean_vol.as_ref().unwrap() - template[l].mean_vol.as_ref().unwrap());
+                vol_sums[l].1 += &(state.precision_vol.as_ref().unwrap()
+                    - template[l].precision_vol.as_ref().unwrap());
+            }
+        }
+        for (layer, state) in reference.layers.iter_mut().zip(template) {
+            layer.state = state;
+        }
+        let inv_n = 1.0 / n_samples as f64;
+        for g in grad_sums.iter_mut().flatten() {
+            g.mapv_inplace(|v| v * inv_n);
+        }
+        opt.apply_dense(&mut ref_state, &mut reference.layers, &grad_sums);
+        for l in 0..n_layers {
+            let state = &mut reference.layers[l].state;
+            state.precision.zip_mut_with(&precision_sums[l], |p, &s| *p += s * inv_n);
+            state
+                .mean_vol
+                .as_mut()
+                .unwrap()
+                .zip_mut_with(&vol_sums[l].0, |p, &s| *p += s * inv_n);
+            state
+                .precision_vol
+                .as_mut()
+                .unwrap()
+                .zip_mut_with(&vol_sums[l].1, |p, &s| *p += s * inv_n);
+        }
+
+        // The batched step on an identically built network.
+        let mut batched = make_net();
+        let mut bat_state = OptState::init(&batched);
+        let errors = batched.batch_update(
+            x.view(),
+            y.view(),
+            Some(&opt),
+            Some(&mut bat_state),
+            1.0,
+            WeightKind::PrecisionWeighted,
+            true,
+        );
+
+        let close = |a: f64, b: f64| (a - b).abs() < 1e-12 * (1.0 + a.abs().max(b.abs()));
+        for (a, b) in errors.iter().zip(ref_errors.iter()) {
+            assert!(close(*a, *b), "input errors differ: {a} vs {b}");
+        }
+        for (bl, rl) in batched.layers.iter().zip(reference.layers.iter()) {
+            if let (Some(bw), Some(rw)) = (bl.weights_in.as_ref(), rl.weights_in.as_ref()) {
+                for (a, b) in bw.iter().zip(rw.iter()) {
+                    assert!(close(*a, *b), "weights differ: {a} vs {b}");
+                }
+            }
+            for (a, b) in bl.state.precision.iter().zip(rl.state.precision.iter()) {
+                assert!(close(*a, *b), "carried precision differs: {a} vs {b}");
+            }
+            for (a, b) in bl
+                .state
+                .mean_vol
+                .as_ref()
+                .unwrap()
+                .iter()
+                .zip(rl.state.mean_vol.as_ref().unwrap().iter())
+            {
+                assert!(close(*a, *b), "carried mean_vol differs: {a} vs {b}");
+            }
+        }
+    }
+
+    /// Splitting the batch across chunks leaves the result unchanged: the
+    /// chunk means recombine to the batch mean, so a four-chunk run matches a
+    /// single-chunk run to floating point reordering noise.
+    #[test]
+    fn test_batch_update_chunked_matches_single_chunk() {
+        let make_net = || {
+            let configs = vec![LayerConfig::new(2), LayerConfig::new(4), LayerConfig::new(3)];
+            let mut net = DeepNet::from_configs(&configs).unwrap();
+            for (l, layer) in net.layers.iter_mut().enumerate().skip(1) {
+                let w = layer.weights_in.as_mut().unwrap();
+                for ((i, j), v) in w.indexed_iter_mut() {
+                    *v = 0.3 * ((i + 2 * j + l) as f64 * 0.7).sin();
+                }
+            }
+            net
+        };
+        let n_samples = 601; // odd, so the chunks are uneven
+        let x = Matrix::from_shape_fn((n_samples, 3), |(i, j)| ((i * 3 + j) as f64 * 0.9).cos());
+        let y = Matrix::from_shape_fn((n_samples, 2), |(i, j)| ((i * 2 + j) as f64 * 0.4).sin());
+        let opt = Optimizer::adam(0.01);
+
+        let run = |n_chunks: usize| {
+            let mut net = make_net();
+            let mut state = OptState::init(&net);
+            let errors = net.batch_update_chunked(
+                x.view(),
+                y.view(),
+                Some(&opt),
+                Some(&mut state),
+                1.0,
+                WeightKind::PrecisionWeighted,
+                true,
+                n_chunks,
+            );
+            (net, errors)
+        };
+        let (net_one, errors_one) = run(1);
+        let (net_four, errors_four) = run(4);
+
+        let close = |a: f64, b: f64| (a - b).abs() < 1e-9 * (1.0 + a.abs().max(b.abs()));
+        for (a, b) in errors_one.iter().zip(errors_four.iter()) {
+            assert!(close(*a, *b), "input errors differ: {a} vs {b}");
+        }
+        for (l1, l4) in net_one.layers.iter().zip(net_four.layers.iter()) {
+            if let (Some(w1), Some(w4)) = (l1.weights_in.as_ref(), l4.weights_in.as_ref()) {
+                for (a, b) in w1.iter().zip(w4.iter()) {
+                    assert!(close(*a, *b), "weights differ: {a} vs {b}");
+                }
+            }
+            for (a, b) in l1.state.precision.iter().zip(l4.state.precision.iter()) {
+                assert!(close(*a, *b), "carried precision differs: {a} vs {b}");
+            }
+        }
+    }
+
+    /// A single-sample batch step applies exactly the weight update of one
+    /// sequential propagation step (the batch mean over one sample is that
+    /// sample's gradient).
+    #[test]
+    fn test_batch_update_single_sample_matches_propagation_step() {
+        let configs = vec![LayerConfig::new(2), LayerConfig::new(3)];
+        let mut seq = DeepNet::from_configs(&configs).unwrap();
+        let mut bat = DeepNet::from_configs(&configs).unwrap();
+        let opt = Optimizer::sgd(0.05);
+        let mut seq_state = OptState::init(&seq);
+        let mut bat_state = OptState::init(&bat);
+
+        let x = Array1::from_vec(vec![0.3, -0.2, 0.8]);
+        let y = Array1::from_vec(vec![0.5, -0.1]);
+
+        seq.propagation_step(
+            x.view(),
+            y.view(),
+            &opt,
+            &mut seq_state,
+            1.0,
+            WeightKind::PrecisionWeighted,
+            true,
+        );
+        let errors = bat.batch_update(
+            x.view().insert_axis(ndarray::Axis(0)),
+            y.view().insert_axis(ndarray::Axis(0)),
+            Some(&opt),
+            Some(&mut bat_state),
+            1.0,
+            WeightKind::PrecisionWeighted,
+            false,
+        );
+        assert_eq!(errors.shape(), &[1, 3]);
+        let ws = seq.layers[1].weights_in.as_ref().unwrap();
+        let wb = bat.layers[1].weights_in.as_ref().unwrap();
+        for (a, b) in ws.iter().zip(wb.iter()) {
+            assert!((a - b).abs() < 1e-12);
+        }
+    }
+
     /// A binary leaf produces sigmoid outputs in (0, 1).
     #[test]
     fn test_binary_leaf_predict_in_unit_interval() {
@@ -342,7 +817,7 @@ mod tests {
             },
             LayerConfig::new(2),
         ];
-        let mut net = DeepNet::from_configs(&configs).unwrap();
+        let net = DeepNet::from_configs(&configs).unwrap();
         let x = Matrix::from_shape_vec((1, 2), vec![0.5, -0.5]).unwrap();
         let out = net.predict_batch(x.view());
         assert!(out[[0, 0]] > 0.0 && out[[0, 0]] < 1.0);
@@ -358,7 +833,7 @@ mod tests {
             },
             LayerConfig::new(2),
         ];
-        let mut net = DeepNet::from_configs(&configs).unwrap();
+        let net = DeepNet::from_configs(&configs).unwrap();
         let x = Matrix::from_shape_vec((1, 2), vec![1.0, -1.0]).unwrap();
         let out = net.predict_batch(x.view());
         assert_eq!(out.shape(), &[1, 3]);

--- a/src/vectorised/optimiser.rs
+++ b/src/vectorised/optimiser.rs
@@ -136,12 +136,99 @@ impl Optimizer {
             }
         }
     }
+
+    /// Apply one optimizer step to every layer's `weights_in` from matched
+    /// per-layer dense descent gradients (`grads[i]` is `None` where the layer
+    /// has no weights). The dense twin of [`Self::apply`], for gradients that
+    /// are not rank-one; [`crate::vectorised::network::DeepNet::batch_update`]
+    /// uses it with the batch-mean gradient, which is a sum of outer products.
+    pub fn apply_dense(
+        &self,
+        state: &mut OptState,
+        layers: &mut [Layer],
+        grads: &[Option<Matrix>],
+    ) {
+        // Same step-counter semantics as `apply`: only Adam advances it.
+        if let Optimizer::Adam { .. } = self {
+            state.t += 1;
+        }
+        for (i, layer) in layers.iter_mut().enumerate() {
+            let grad = match &grads[i] {
+                Some(g) => g,
+                None => continue,
+            };
+            let weights = layer
+                .weights_in
+                .as_mut()
+                .expect("gradient present but layer has no weights");
+
+            match *self {
+                Optimizer::Sgd { lr } => {
+                    ndarray::Zip::from(&mut *weights)
+                        .and(grad)
+                        .for_each(|w, &g| *w -= lr * g);
+                }
+                Optimizer::Adam { lr, b1, b2, eps } => {
+                    let (m, mv) = state.moments[i]
+                        .as_mut()
+                        .expect("Adam moments missing for a weighted layer");
+                    let bc1 = 1.0 - b1.powi(state.t);
+                    let bc2 = 1.0 - b2.powi(state.t);
+                    ndarray::Zip::from(&mut *weights)
+                        .and(&mut *m)
+                        .and(&mut *mv)
+                        .and(grad)
+                        .for_each(|w, m_, v_, &g| {
+                            *w -= crate::optimiser::adam_step(
+                                m_, v_, g, b1, b2, bc1, bc2, lr, eps,
+                            );
+                        });
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::vectorised::layer::{DeepNet, LayerConfig};
+
+    /// `apply` and `apply_dense` produce the same step from the same gradient,
+    /// whether given as rank-one factors or as the materialised matrix.
+    #[test]
+    fn test_apply_dense_matches_factor_apply() {
+        let mut net_a = DeepNet::from_configs(&[LayerConfig::new(2), LayerConfig::new(2)]).unwrap();
+        let mut net_b = DeepNet::from_configs(&[LayerConfig::new(2), LayerConfig::new(2)]).unwrap();
+        let mut state_a = OptState::init(&net_a);
+        let mut state_b = OptState::init(&net_b);
+
+        let u = Vector::from_vec(vec![0.5, -1.5]);
+        let v = Vector::from_vec(vec![2.0, 1.0, -0.5]);
+        let dense = {
+            let mut g = Matrix::zeros((2, 3));
+            for i in 0..2 {
+                for j in 0..3 {
+                    g[[i, j]] = u[i] * v[j];
+                }
+            }
+            g
+        };
+        let opt = Optimizer::adam(0.01);
+        for _ in 0..3 {
+            opt.apply(
+                &mut state_a,
+                &mut net_a.layers,
+                &[None, Some((u.clone(), v.clone()))],
+            );
+            opt.apply_dense(&mut state_b, &mut net_b.layers, &[None, Some(dense.clone())]);
+        }
+        let wa = net_a.layers[1].weights_in.as_ref().unwrap();
+        let wb = net_b.layers[1].weights_in.as_ref().unwrap();
+        for (a, b) in wa.iter().zip(wb.iter()) {
+            assert!((a - b).abs() < 1e-12);
+        }
+    }
 
     #[test]
     fn test_sgd_step_descends() {

--- a/tests/test_rs_deepnetwork.py
+++ b/tests/test_rs_deepnetwork.py
@@ -409,6 +409,112 @@ def test_fit_parity_categorical_output():
     )
 
 
+def test_batch_update_validation():
+    """Reject non-batched input, unknown options, and single-layer networks."""
+    net = _build_rs([2, 3])
+    x = np.zeros((4, 3))
+    y = np.zeros((4, 2))
+    with pytest.raises(ValueError, match="must be 2D"):
+        net.batch_update(np.zeros(3), np.zeros(2))
+    with pytest.raises(ValueError, match="Unknown optimizer"):
+        net.batch_update(x, y, optimizer="nope")
+    with pytest.raises(ValueError, match="Unknown learning_kind"):
+        net.batch_update(x, y, learning_kind="nope")
+    with pytest.raises(ValueError, match="same number of samples"):
+        net.batch_update(x, np.zeros((3, 2)))
+    single = RsDeepNetwork().add_layer(2)
+    with pytest.raises(ValueError, match="single layer"):
+        single.batch_update(np.zeros((4, 2)), np.zeros((4, 2)))
+
+
+@pytest.mark.parametrize("optimizer", ["sgd", "adam"])
+def test_batch_update_trajectory_parity(optimizer):
+    """Input errors and weights agree with JAX over several batch steps."""
+    rng = np.random.default_rng(30)
+    rs, jx = _matched_pair([2, 4, 3], rng)
+    make_optax = {"sgd": lambda: optax.sgd(0.05), "adam": lambda: optax.adam(1e-2)}
+    lr = {"sgd": 0.05, "adam": 1e-2}
+    optax_opt = make_optax[optimizer]()
+    for _ in range(5):
+        x = rng.normal(size=(8, 3))
+        y = rng.normal(size=(8, 2))
+        errors_rs = rs.batch_update(
+            x, y, optimizer=optimizer, learning_rate=lr[optimizer]
+        )
+        jx.batch_update(x, y, optimizer=optax_opt)
+        np.testing.assert_allclose(
+            errors_rs, np.asarray(jx.input_errors), rtol=1e-6, atol=1e-9
+        )
+    jx_weights = [np.asarray(layer.weights_in) for layer in jx.state.layers[1:]]
+    for w_rs, w_jx in zip(rs.get_weights(), jx_weights):
+        np.testing.assert_allclose(w_rs, w_jx, rtol=1e-6, atol=1e-9)
+
+
+def test_batch_update_parity_pinned_confidences():
+    """With pinned confidences the batch step still matches JAX exactly."""
+    rng = np.random.default_rng(31)
+    rs, jx = _matched_pair([2, 3, 3], rng)
+    x = rng.normal(size=(6, 3))
+    y = rng.normal(size=(6, 2))
+    for _ in range(3):
+        errors_rs = rs.batch_update(
+            x,
+            y,
+            optimizer="sgd",
+            learning_rate=0.05,
+            update_confidences=False,
+        )
+        jx.batch_update(x, y, optimizer=optax.sgd(0.05), update_confidences=False)
+    np.testing.assert_allclose(
+        errors_rs, np.asarray(jx.input_errors), rtol=1e-6, atol=1e-9
+    )
+    jx_weights = [np.asarray(layer.weights_in) for layer in jx.state.layers[1:]]
+    for w_rs, w_jx in zip(rs.get_weights(), jx_weights):
+        np.testing.assert_allclose(w_rs, w_jx, rtol=1e-6, atol=1e-9)
+
+
+def test_batch_update_frozen_weights():
+    """Without an optimizer the weights stay untouched; errors still agree."""
+    rng = np.random.default_rng(32)
+    rs, jx = _matched_pair([2, 3], rng)
+    weights_before = [np.array(w) for w in rs.get_weights()]
+    x = rng.normal(size=(6, 3))
+    y = rng.normal(size=(6, 2))
+    errors_rs = rs.batch_update(x, y)
+    jx.batch_update(x, y)
+    np.testing.assert_allclose(
+        errors_rs, np.asarray(jx.input_errors), rtol=1e-6, atol=1e-9
+    )
+    for got, expected in zip(rs.get_weights(), weights_before):
+        np.testing.assert_array_equal(got, expected)
+
+
+def test_batch_update_parity_categorical_output():
+    """The batch step agrees with JAX under a categorical output layer."""
+    rng = np.random.default_rng(33)
+    rs = RsDeepNetwork(volatility_updates="eHGF")
+    rs.add_layer(3, kind="categorical").add_layer(4)
+    jx = JaxDeepNetwork(volatility_updates="eHGF")
+    jx.add_layer(size=3, kind="categorical").add_layer(size=4)
+    weights = _random_weights(rs, rng)
+    rs.set_weights(weights)
+    _inject_jax_weights(jx, weights)
+    x = rng.normal(size=(8, 4))
+    y = np.eye(3)[rng.integers(0, 3, size=8)]
+    # One optax object for the whole run: a new object per call would reset
+    # the optimiser state, which the Rust class keeps across calls.
+    optax_opt = optax.adam(1e-2)
+    for _ in range(3):
+        errors_rs = rs.batch_update(x, y, optimizer="adam", learning_rate=1e-2)
+        jx.batch_update(x, y, optimizer=optax_opt)
+    np.testing.assert_allclose(
+        errors_rs, np.asarray(jx.input_errors), rtol=1e-6, atol=1e-9
+    )
+    jx_weights = [np.asarray(layer.weights_in) for layer in jx.state.layers[1:]]
+    for w_rs, w_jx in zip(rs.get_weights(), jx_weights):
+        np.testing.assert_allclose(w_rs, w_jx, rtol=1e-6, atol=1e-9)
+
+
 def test_predict_parity_binary_output():
     """Match the JAX forward pass with a binary output layer."""
     rng = np.random.default_rng(17)


### PR DESCRIPTION
This PR adds batch-synchronous learning to the Rust backend: `pyhgf.rshgf.DeepNetwork.batch_update` mirrors the JAX `DeepNetwork.batch_update`, sweeping every sample of a batch from the same beliefs and applying the averaged weight gradients and confidence increments once. The step runs on new batched kernels (`src/vectorised/batched.rs`) that hold the layer state with a trailing samples axis so each phase is one matrix product per layer in a features by samples layout, and large batches are split into per-thread slabs via rayon and recombined exactly (samples are exchangeable).