### PR TITLE
Fused query, key, and value projections in the attention composite

### DIFF
--- a/pyhgf/model/__init__.py
+++ b/pyhgf/model/__init__.py
@@ -33,7 +33,7 @@ from .hybrid import (
 )
 from .network import Network
 from .transformer import HybridGPT, MultiHeadAttention, hybrid_from_gpt
-from .transplant import from_embedding, from_feedforward, from_linear
+from .transplant import from_embedding, from_feedforward, from_linear, from_linears
 
 __all__ = [
     "Network",
@@ -44,6 +44,7 @@ __all__ = [
     "ObservedMinusPredicted",
     "validate_error_convention",
     "from_linear",
+    "from_linears",
     "from_feedforward",
     "from_embedding",
     "PCModule",

--- a/pyhgf/model/fused.py
+++ b/pyhgf/model/fused.py
@@ -207,6 +207,43 @@ def _residual_core(part: Residual, path: str) -> _Core:
     return _Core(inner.init_state, forward, backward, inner.write_back)
 
 
+def _fused_qkv_attention_core(part: MultiHeadAttention, path: str) -> _Core:
+    """Build the attention core over one fused query/key/value part.
+
+    The part emits the stacked ``[q | k | v]`` streams, split after the part
+    on the way out and concatenated on the way back: the same three linear
+    maps as one matrix product.
+    """
+    assert part.wqkv is not None
+    qkv_core = _core(part.wqkv, f"{path}.wqkv")
+    o_core = _core(part.wo, f"{path}.wo")
+    n_heads = part.n_heads
+    init_state_pytree = (qkv_core.init_state, o_core.init_state)
+
+    def forward(state, x):
+        state_qkv, state_o = state
+        qkv, cache_qkv = qkv_core.forward(state_qkv, x)
+        q, k, v = jnp.split(qkv, 3, axis=-1)
+        ctx, cache_mix = _mixing_forward(q, k, v, n_heads)
+        y, cache_o = o_core.forward(state_o, ctx)
+        return y, (cache_qkv, cache_mix, cache_o)
+
+    def backward(state, cache, error):
+        state_qkv, state_o = state
+        cache_qkv, cache_mix, cache_o = cache
+        d_ctx, new_o, report_o = o_core.backward(state_o, cache_o, error)
+        d_q, d_k, d_v = _mixing_backward(cache_mix, d_ctx)
+        d_qkv = jnp.concatenate([d_q, d_k, d_v], axis=-1)
+        error_qkv, new_qkv, report_qkv = qkv_core.backward(state_qkv, cache_qkv, d_qkv)
+        return error_qkv, (new_qkv, new_o), report_qkv + report_o
+
+    def write_back(state):
+        qkv_core.write_back(state[0])
+        o_core.write_back(state[1])
+
+    return _Core(init_state_pytree, forward, backward, write_back)
+
+
 def _attention_core(part: MultiHeadAttention, path: str) -> _Core:
     """Build the core of the attention composite: Q/K/V, the mixing, then O.
 
@@ -218,6 +255,9 @@ def _attention_core(part: MultiHeadAttention, path: str) -> _Core:
     already been initialized via their respective ``init_state()`` calls during _core
     construction.
     """
+    if part.wqkv is not None:
+        return _fused_qkv_attention_core(part, path)
+    n_heads = part.n_heads
     q_core, k_core, v_core, o_core = (
         _core(child, f"{path}.{name}")
         for name, child in (
@@ -227,7 +267,6 @@ def _attention_core(part: MultiHeadAttention, path: str) -> _Core:
             ("wo", part.wo),
         )
     )
-    n_heads = part.n_heads
 
     # Aggregate init_state pytrees from all four cores.
     init_state_pytree = tuple(

--- a/pyhgf/model/transformer.py
+++ b/pyhgf/model/transformer.py
@@ -46,6 +46,11 @@ class MultiHeadAttention(PCModule):
 
     Holds four single-input parts for the Q, K, V, and O weight tables (any
     mix of frozen and learning parts) around the weight-free mixing step.
+    The query, key, and value projections read the same input, so they can
+    instead be one fused part ``wqkv`` whose output stacks the three streams
+    on the feature axis, ``[q | k | v]``: the same three linear maps
+    computed as one matrix product, with the three routed errors
+    concatenated on the way back.
     Operates on ``(batch, seq, features)`` arrays — attention is the one
     part that needs the sequence axis explicit, because it moves information
     *between* positions; everywhere else each position is independent.
@@ -65,17 +70,41 @@ class MultiHeadAttention(PCModule):
 
     def __init__(
         self,
-        wq: PCModule,
-        wk: PCModule,
-        wv: PCModule,
-        wo: PCModule,
-        n_heads: int,
+        wq: Optional[PCModule] = None,
+        wk: Optional[PCModule] = None,
+        wv: Optional[PCModule] = None,
+        wo: Optional[PCModule] = None,
+        n_heads: int = 1,
+        *,
+        wqkv: Optional[PCModule] = None,
     ):
-        self.wq, self.wk, self.wv, self.wo = wq, wk, wv, wo
+        if wo is None:
+            raise ValueError("MultiHeadAttention requires an output part `wo`.")
+        if wqkv is not None:
+            if wq is not None or wk is not None or wv is not None:
+                raise ValueError(
+                    "Pass either the fused `wqkv` part or the separate "
+                    "`wq`/`wk`/`wv` parts, not both."
+                )
+        elif wq is None or wk is None or wv is None:
+            raise ValueError(
+                "MultiHeadAttention requires `wq`, `wk`, and `wv` parts, or "
+                "one fused `wqkv` part."
+            )
+        self.wq, self.wk, self.wv = wq, wk, wv
+        self.wo: PCModule = wo
+        self.wqkv = wqkv
         self.n_heads = n_heads
 
     def init_state(self) -> tuple:
-        """Return the ``(q, k, v, o)`` tuple of the four weight tables' states."""
+        """Return the weight tables' state tuple.
+
+        ``(qkv, o)`` with the fused projection part, ``(q, k, v, o)`` with the separate
+        ones.
+        """
+        if self.wqkv is not None:
+            return (self.wqkv.init_state(), self.wo.init_state())
+        assert self.wq is not None and self.wk is not None and self.wv is not None
         return (
             self.wq.init_state(),
             self.wk.init_state(),
@@ -222,7 +251,11 @@ def hybrid_from_gpt(
         feed-forwards.
     attention_parts :
         Optional list of dicts, one per block, with keys ``"wq"``, ``"wk"``,
-        ``"wv"``, ``"wo"``, replacing the frozen attention weight tables.
+        ``"wv"``, ``"wo"``, replacing the frozen attention weight tables; or
+        a ``"wqkv"`` key carrying one fused part for the stacked
+        ``[q | k | v]`` projections (e.g. built with
+        :func:`~pyhgf.model.transplant.from_linears`), alongside an
+        optional ``"wo"``.
     head_part :
         Optional part replacing the frozen output head.
     token_part, position_part :
@@ -237,13 +270,22 @@ def hybrid_from_gpt(
     layers: list = []
     for i, block in enumerate(gpt.blocks):
         attn_tables = attention_parts[i] if attention_parts is not None else {}
-        attention = MultiHeadAttention(
-            wq=attn_tables.get("wq") or linear_adapter(block.attn.wq),
-            wk=attn_tables.get("wk") or linear_adapter(block.attn.wk),
-            wv=attn_tables.get("wv") or linear_adapter(block.attn.wv),
-            wo=attn_tables.get("wo") or linear_adapter(block.attn.wo),
-            n_heads=block.attn.n_heads,
-        )
+        if "wqkv" in attn_tables:
+            # One fused projection part for the stacked ``[q | k | v]``
+            # streams; the reference model's separate tables stay unused.
+            attention = MultiHeadAttention(
+                wqkv=attn_tables["wqkv"],
+                wo=attn_tables.get("wo") or linear_adapter(block.attn.wo),
+                n_heads=block.attn.n_heads,
+            )
+        else:
+            attention = MultiHeadAttention(
+                wq=attn_tables.get("wq") or linear_adapter(block.attn.wq),
+                wk=attn_tables.get("wk") or linear_adapter(block.attn.wk),
+                wv=attn_tables.get("wv") or linear_adapter(block.attn.wv),
+                wo=attn_tables.get("wo") or linear_adapter(block.attn.wo),
+                n_heads=block.attn.n_heads,
+            )
         if ff_parts is not None:
             feed_forward = ff_parts[i]
         else:

--- a/pyhgf/model/transplant.py
+++ b/pyhgf/model/transplant.py
@@ -100,6 +100,62 @@ def from_linear(
     return _set_weights(net, {1: _weights_with_bias(linear.weight, linear.bias)})
 
 
+def from_linears(
+    linears: list,
+    leaf_kwargs: Optional[dict] = None,
+    layer_kwargs: Optional[dict] = None,
+) -> DeepNetwork:
+    """Build a two-layer network stacking several Linears that share one input.
+
+    The layers' outputs are concatenated on the feature axis in the given
+    order: the bottom (output) layer has the summed ``out_features``, the top
+    (input) layer the shared ``in_features``, and the connecting matrix
+    stacks the weights row-wise (with the biases folded in as the last
+    column when present). The canonical use is the fused query/key/value
+    projection of an attention block, whose three tables read the same
+    input and can be one matrix product.
+
+    Parameters
+    ----------
+    linears :
+        The Equinox layers to stack. All must share ``in_features``, and
+        either all or none carry a bias.
+    leaf_kwargs :
+        Extra ``add_layer`` keyword arguments for the bottom (observed)
+        layer.
+    layer_kwargs :
+        Extra ``add_layer`` keyword arguments for the top (input) layer.
+
+    Returns
+    -------
+    DeepNetwork
+        A network whose ``predict`` reproduces the stacked forward passes.
+    """
+    in_features = {linear.weight.shape[1] for linear in linears}
+    if len(in_features) != 1:
+        raise ValueError("All stacked Linears must share in_features.")
+    has_bias = {linear.bias is not None for linear in linears}
+    if len(has_bias) != 1:
+        raise ValueError("Either all or none of the stacked Linears may have a bias.")
+    weight = jnp.concatenate([jnp.asarray(linear.weight) for linear in linears], axis=0)
+    bias = (
+        jnp.concatenate([jnp.asarray(linear.bias) for linear in linears])
+        if has_bias.pop()
+        else None
+    )
+    out_features, in_features = weight.shape
+    net = (
+        DeepNetwork()
+        .add_layer(size=out_features, add_constant_input=False, **(leaf_kwargs or {}))
+        .add_layer(
+            size=in_features,
+            add_constant_input=bias is not None,
+            **(layer_kwargs or {}),
+        )
+    )
+    return _set_weights(net, {1: _weights_with_bias(weight, bias)})
+
+
 def from_feedforward(
     fc1: eqx.nn.Linear,
     fc2: eqx.nn.Linear,

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -248,6 +248,70 @@ def test_fused_qkv_matches_separate():
         np.testing.assert_allclose(err_fused, err_sep, rtol=1e-3, atol=1e-4)
 
 
+def test_fused_qkv_validation():
+    """The attention composite rejects inconsistent projection slots."""
+    import pytest
+
+    eqx_attn = EqxAttention(16, 4, key=random.key(0))
+    q = linear_adapter(eqx_attn.wq)
+    o = linear_adapter(eqx_attn.wo)
+    stacked = linear_adapter(eqx_attn.wq)  # any part will do for the slot
+    with pytest.raises(ValueError, match="output part"):
+        MultiHeadAttention(wq=q, wk=q, wv=q, n_heads=4)
+    with pytest.raises(ValueError, match="not both"):
+        MultiHeadAttention(wq=q, wqkv=stacked, wo=o, n_heads=4)
+    with pytest.raises(ValueError, match="one fused"):
+        MultiHeadAttention(wq=q, wk=q, wo=o, n_heads=4)
+
+
+def test_fused_qkv_through_hybrid_and_merge():
+    """hybrid_from_gpt wires the fused slot, and merge writes it back.
+
+    The fused hybrid must reproduce the reference model's logits (the stacked part
+    carries the same weights), and after a training step ``merge`` must write the
+    advanced fused weights back onto the part.
+    """
+    from pyhgf.model import from_linears
+
+    rng = np.random.default_rng(9)
+    vocab, dim, n_heads, hidden, n_layers, seq_len = 11, 16, 4, 32, 1, 8
+    gpt = EqxGPT(vocab, dim, n_heads, hidden, n_layers, seq_len, key=random.key(8))
+    ids = jnp.asarray(rng.integers(0, vocab, size=(2, seq_len)))
+    targets = jnp.asarray(rng.integers(0, vocab, size=(2, seq_len)))
+
+    qkv_parts = [
+        DeepNetworkAdapter(
+            from_linears(
+                [b.attn.wq, b.attn.wk, b.attn.wv],
+                leaf_kwargs=_PARITY_LEAF,
+                layer_kwargs=_PARITY,
+            ),
+            optimizer=optax.adam(1e-3),
+        )
+        for b in gpt.blocks
+    ]
+    hybrid = hybrid_from_gpt(
+        gpt,
+        attention_parts=[{"wqkv": part} for part in qkv_parts],
+    )
+    pipeline = FusedPipeline(
+        hybrid,
+        error_fn=lambda logits, y: (
+            jax.nn.softmax(logits, axis=-1) - jax.nn.one_hot(y, vocab)
+        ),
+    )
+    # The head slot stays frozen here, so the pipeline's output is the
+    # reference model's logits.
+    reference = jax.vmap(gpt)(ids)
+    np.testing.assert_allclose(pipeline.predict(ids), reference, rtol=1e-4, atol=1e-5)
+
+    before = np.asarray(qkv_parts[0].net.state.layers[1].weights_in)
+    pipeline.step(ids, targets)
+    pipeline.merge()
+    after = np.asarray(qkv_parts[0].net.state.layers[1].weights_in)
+    assert not np.allclose(before, after)  # the fused weights learnt
+
+
 def test_full_model_forward_gate():
     """The fully transplanted, fully frozen model reproduces the Equinox GPT.
 

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -167,6 +167,87 @@ def test_attention_backward_matches_autodiff():
     np.testing.assert_allclose(error_in, vjp(error)[0], rtol=1e-4, atol=1e-5)
 
 
+def test_fused_qkv_matches_separate():
+    """One fused ``wqkv`` part reproduces the separate Q/K/V parts.
+
+    Frozen: the fused composite's forward and routed input error must match
+    the separate composite's (and therefore autodiff, which the separate
+    composite is tested against). Learning: adapters built from the same
+    weights by ``from_linears`` must follow the same training trajectory as
+    three separate ``from_linear`` adapters, step for step.
+    """
+    from pyhgf.model import from_linear, from_linears
+
+    rng = np.random.default_rng(2)
+    dim, n_heads, seq_len, batch = 16, 4, 8, 3
+    eqx_attn = EqxAttention(dim, n_heads, key=random.key(3))
+    x = jnp.asarray(rng.normal(size=(batch, seq_len, dim)).astype("float32"))
+    error = jnp.asarray(rng.normal(size=(batch, seq_len, dim)).astype("float32"))
+
+    # Frozen gate: one stacked Linear behind the fused slot.
+    stacked = eqx.nn.Linear(dim, 3 * dim, use_bias=False, key=random.key(4))
+    stacked = eqx.tree_at(
+        lambda linear: linear.weight,
+        stacked,
+        jnp.concatenate(
+            [eqx_attn.wq.weight, eqx_attn.wk.weight, eqx_attn.wv.weight], axis=0
+        ),
+    )
+    separate = FusedPipeline(
+        MultiHeadAttention(
+            wq=linear_adapter(eqx_attn.wq),
+            wk=linear_adapter(eqx_attn.wk),
+            wv=linear_adapter(eqx_attn.wv),
+            wo=linear_adapter(eqx_attn.wo),
+            n_heads=n_heads,
+        ),
+        error_fn=lambda out, e: e,
+    )
+    fused = FusedPipeline(
+        MultiHeadAttention(
+            wqkv=linear_adapter(stacked),
+            wo=linear_adapter(eqx_attn.wo),
+            n_heads=n_heads,
+        ),
+        error_fn=lambda out, e: e,
+    )
+    out_sep, err_sep = separate.step(x, error)
+    out_fused, err_fused = fused.step(x, error)
+    np.testing.assert_allclose(out_fused, out_sep, rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(err_fused, err_sep, rtol=1e-4, atol=1e-5)
+
+    # Learning gate: the same weights as learning parts, two steps.
+    def learner(linear_or_list, builder):
+        return DeepNetworkAdapter(
+            builder(linear_or_list, leaf_kwargs=_PARITY_LEAF, layer_kwargs=_PARITY),
+            optimizer=optax.adam(1e-2),
+        )
+
+    separate = FusedPipeline(
+        MultiHeadAttention(
+            wq=learner(eqx_attn.wq, from_linear),
+            wk=learner(eqx_attn.wk, from_linear),
+            wv=learner(eqx_attn.wv, from_linear),
+            wo=learner(eqx_attn.wo, from_linear),
+            n_heads=n_heads,
+        ),
+        error_fn=lambda out, e: e,
+    )
+    fused = FusedPipeline(
+        MultiHeadAttention(
+            wqkv=learner([eqx_attn.wq, eqx_attn.wk, eqx_attn.wv], from_linears),
+            wo=learner(eqx_attn.wo, from_linear),
+            n_heads=n_heads,
+        ),
+        error_fn=lambda out, e: e,
+    )
+    for _ in range(2):
+        out_sep, err_sep = separate.step(x, error)
+        out_fused, err_fused = fused.step(x, error)
+        np.testing.assert_allclose(out_fused, out_sep, rtol=1e-4, atol=1e-5)
+        np.testing.assert_allclose(err_fused, err_sep, rtol=1e-3, atol=1e-4)
+
+
 def test_full_model_forward_gate():
     """The fully transplanted, fully frozen model reproduces the Equinox GPT.
 

--- a/tests/test_transplant.py
+++ b/tests/test_transplant.py
@@ -119,3 +119,30 @@ def test_transplanted_feedforward_learns_like_backprop_with_biases():
     # PyHGF errors are observed-minus-predicted: the negative of the loss
     # gradient at the input.
     assert norm_rel(-net.input_errors, per_sample_dx) < 1e-2
+
+
+def test_from_linears_stacks_and_validates():
+    """Stack shared-input Linears, rejecting mismatched inputs or mixed biases."""
+    import pytest
+
+    from pyhgf.model import from_linears
+
+    k1, k2, k3 = random.split(random.key(0), 3)
+    a = eqx.nn.Linear(4, 3, key=k1)
+    b = eqx.nn.Linear(4, 5, key=k2)
+    x = jnp.asarray(np.random.default_rng(0).normal(size=(6, 4)).astype("float32"))
+
+    net = from_linears([a, b], leaf_kwargs=dict(volatility_parent=False))
+    stacked = np.concatenate(
+        [np.asarray(jax.vmap(a)(x)), np.asarray(jax.vmap(b)(x))], axis=1
+    )
+    np.testing.assert_allclose(
+        np.asarray(net.predict(x)), stacked, rtol=1e-5, atol=1e-6
+    )
+
+    wrong_input = eqx.nn.Linear(5, 3, key=k3)
+    with pytest.raises(ValueError, match="in_features"):
+        from_linears([a, wrong_input])
+    no_bias = eqx.nn.Linear(4, 3, use_bias=False, key=k3)
+    with pytest.raises(ValueError, match="bias"):
+        from_linears([a, no_bias])


### PR DESCRIPTION
The Q, K, and V projections read the same input, so they can be one part whose output stacks the streams on the feature axis, `[q | k | v]`: the same three linear maps computed as one matrix product, with the three routed errors concatenated on the way back. `MultiHeadAttention` gains an alternative `wqkv` slot, `hybrid_from_gpt` accepts a `wqkv` key in the attention part dicts, and `from_linears` builds the fused part from several Equinox Linears sharing one input.

The separate-projection composite remains the default and is unchanged. Tests gate the fused slot against the separate one, frozen (forward and routed input error) and learning (two identical training steps from the same weights).